### PR TITLE
keystone: Enable http2

### DIFF
--- a/keystone/keystone.wsgi.conf
+++ b/keystone/keystone.wsgi.conf
@@ -1,5 +1,5 @@
 server {
-       listen 35357 ssl;
+       listen 35357 ssl http2;
        server_name IDENTITY_HOST;
        ssl_certificate /etc/nginx/ssl/keystone_cert.pem;
        ssl_certificate_key /etc/nginx/ssl/keystone_key.pem;
@@ -38,7 +38,7 @@ server {
 }
 
 server {
-       listen 5000 ssl;
+       listen 5000 ssl http2;
        server_name IDENTITY_HOST;
        ssl_certificate /etc/nginx/ssl/keystone_cert.pem;
        ssl_certificate_key /etc/nginx/ssl/keystone_key.pem;


### PR DESCRIPTION
nginx in clearlinux supports http2

This commit enables this feature for improved speed.

Signed-off-by: Alberto Murillo <alberto.murillo.silva@intel.com>