### PR TITLE
Add `ciao-deploy` Dockerfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ https://hub.docker.com/u/clearlinux/
 
 Containers
 ----------
+- Ciao-deploy
 - CIAO-WebUI
 - Keystone
 - MariaDB

--- a/ciao-deploy/Dockerfile
+++ b/ciao-deploy/Dockerfile
@@ -1,0 +1,14 @@
+FROM clearlinux
+MAINTAINER marcos.simental.magana@intel.com
+
+ARG swupd_args
+ENV HOME=/root/
+
+RUN swupd bundle-add sysadmin-hostmgmt go-basic c-basic kvm-host openstack-common $swupd_args
+
+RUN cp -r /usr/share/ansible/examples/ciao /root/
+RUN ansible-galaxy install -r /root/ciao/requirements.yml --ignore-certs
+
+RUN rm -rf /var/lib/swupd
+
+CMD 'bash'

--- a/ciao-deploy/README.md
+++ b/ciao-deploy/README.md
@@ -1,0 +1,47 @@
+Ciao Deploy
+==========
+[![](https://images.microbadger.com/badges/image/clearlinux/ciao-deploy.svg)](http://microbadger.com/images/clearlinux/ciao-deploy "Get your own image badge on microbadger.com")
+[![](https://images.microbadger.com/badges/version/clearlinux/ciao-deploy.svg)](http://microbadger.com/images/clearlinux/ciao-deploy "Get your own version badge on microbadger.com")
+
+This provides a ciao deployment container.
+
+Build
+-----
+```
+    docker build -t clearlinux/ciao-deploy .
+```
+
+Or just pull it from Dockerhub
+------------------------------
+```
+    docker pull clearlinux/ciao-deploy
+```
+
+Run the Ciao-deploy Container
+----------------------------
+```
+    docker run -it clearlinux/ciao-deploy
+```
+
+If you have setup your ssh key for the ansible setup, you may want to use it
+in your ciao-deploy container:
+
+```
+    docker run -v /path/to/your/.ssh/key:/root/.ssh/key \
+               -it clearlinux/ciao-deploy
+```
+
+Setup your cluster configuration
+--------------------------------
+You may need to edit `/root/ciao/group_vars/all` and `/root/ciao/hosts` to
+suit your cluster setup needs.
+
+For more detailed instructions you may want to check
+[Deploying ciao via automation](https://clearlinux.org/documentation/ciao-deploy.html)
+documentation.
+
+Extra Build ARGs
+----------------
+- ``swupd_args`` Specifies [SWUPD](https://clearlinux.org/documentation/swupdate_how_to_run_the_updater.html) flags
+
+Default build args in Docker are on: https://docs.docker.com/engine/reference/builder/#/arg


### PR DESCRIPTION
This commits adds a dockerfile useful to create a
container which fulfills all the requirements for
the deployment node in a ciao cluster setup.

By using the `ciao-deploy` container, operator shouldn't
require to install anything else in order to get a ciao
deployment node.

Signed-off-by: Simental Magana, Marcos <marcos.simental.magana@intel.com>