### PR TITLE
ciao-deploy: remove kvm-host bundle install

### DIFF
--- a/ciao-deploy/Dockerfile
+++ b/ciao-deploy/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER marcos.simental.magana@intel.com
 ARG swupd_args
 ENV HOME=/root/
 
-RUN swupd bundle-add sysadmin-hostmgmt go-basic c-basic kvm-host openstack-common $swupd_args
+RUN swupd bundle-add sysadmin-hostmgmt go-basic c-basic openstack-common $swupd_args
 
 RUN cp -r /usr/share/ansible/examples/ciao /root/
 RUN ansible-galaxy install -r /root/ciao/requirements.yml --ignore-certs


### PR DESCRIPTION
the kvm-host bundle was added to include the qemu-nbd tool,
since this is not neccessary for the ciao-deployment, we can
get rid of this bundle.

Signed-off-by: Simental Magana, Marcos <marcos.simental.magana@intel.com>