### PR TITLE
ciao-deploy: Add cryptography bundle

### DIFF
--- a/ciao-deploy/Dockerfile
+++ b/ciao-deploy/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER marcos.simental.magana@intel.com
 ARG swupd_args
 ENV HOME=/root/
 
-RUN swupd bundle-add sysadmin-hostmgmt go-basic c-basic openstack-common $swupd_args
+RUN swupd bundle-add cryptography sysadmin-hostmgmt go-basic c-basic openstack-common $swupd_args
 
 RUN cp -r /usr/share/ansible/examples/ciao /root/
 RUN ansible-galaxy install -r /root/ciao/requirements.yml --ignore-certs


### PR DESCRIPTION
previous to this change, there was no explicit requirement
of the openssl tools. The cryptography bundle provides this
functionality.

Signed-off-by: Simental Magana, Marcos <marcos.simental.magana@intel.com>