### PR TITLE
Add `machine-learning` Dockerfile

### DIFF
--- a/machine-learning/Dockerfile
+++ b/machine-learning/Dockerfile
@@ -1,0 +1,10 @@
+FROM clearlinux
+MAINTAINER marcos.simental.magana@intel.com
+
+ARG swupd_args
+
+RUN swupd bundle-add machine-learning-basic R-basic R-basic
+
+RUN rm -rf /var/lib/swupd
+
+CMD 'bash'

--- a/machine-learning/README.md
+++ b/machine-learning/README.md
@@ -1,0 +1,35 @@
+Machine Learning
+================
+[![](https://images.microbadger.com/badges/image/clearlinux/machine-learning.svg)](http://microbadger.com/images/clearlinux/machine-learning "Get your own image badge on microbadger.com")
+[![](https://images.microbadger.com/badges/version/clearlinux/machine-learning.svg)](http://microbadger.com/images/clearlinux/machine-learning "Get your own version badge on microbadger.com")
+
+This provides a machine learning environment with the `machine-learning-basic`,
+`R-basic` and `R-extras` bundles from [Clearlinux](https://clearlinux.org/documentation/bundles_overview.html)
+
+Build
+-----
+```
+docker build -t clearlinux/machine-learning .
+```
+
+Or just pull it from Dockerhub
+------------------------------
+```
+docker pull clearlinux/machine-learning
+```
+
+Run the machine-learning Container
+----------------------------------
+```
+docker run -it clearlinux/machine-learning
+```
+
+Environment Variables
+---------------------
+none
+
+Extra Build ARGs
+----------------
+- ``swupd_args`` Specifies [SWUPD](https://clearlinux.org/documentation/swupdate_how_to_run_the_updater.html) flags
+
+Default build args in Docker are on: https://docs.docker.com/engine/reference/builder/#/arg


### PR DESCRIPTION
This commits adds a Dockerfile to create a machine-learning docker container,
useful to develop machine-learning solutions based on R language and
other python packages such as scipy, scikit-learn and others.

Signed-off-by: Simental Magana, Marcos <marcos.simental.magana@intel.com>