### PR TITLE
ciao-deploy: add `editors` bundle to container

### DIFF
--- a/ciao-deploy/Dockerfile
+++ b/ciao-deploy/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER marcos.simental.magana@intel.com
 ARG swupd_args
 ENV HOME=/root/
 
-RUN swupd bundle-add cryptography sysadmin-hostmgmt go-basic c-basic openstack-common $swupd_args
+RUN swupd bundle-add cryptography editors sysadmin-hostmgmt go-basic c-basic openstack-common $swupd_args
 
 RUN cp -r /usr/share/ansible/examples/ciao /root/
 RUN ansible-galaxy install -r /root/ciao/requirements.yml --ignore-certs


### PR DESCRIPTION
The usage of this container involves file edits, however, there is
not a single editor in the contaier, making it useless until the user
installs the editors bundle.

this commits adds the editors bundle to avoid this painful step to the
user.

Signed-off-by: Simental Magana, Marcos <marcos.simental.magana@intel.com>