### PR TITLE
ciao-deploy: fix ansible install of playbooks

### DIFF
--- a/ciao-deploy/Dockerfile
+++ b/ciao-deploy/Dockerfile
@@ -6,7 +6,7 @@ ENV HOME=/root/
 
 RUN swupd bundle-add cryptography sysadmin-hostmgmt go-basic c-basic openstack-common $swupd_args
 
-RUN ansible-galaxy install -r /root/ciao/requirements.yml --ignore-certs
+RUN ansible-galaxy install -r /usr/share/ansible/examples/ciao/requirements.yml --ignore-certs
 
 RUN rm -rf /var/lib/swupd
 


### PR DESCRIPTION
With previous change, the clearlinux roles on the docker image
are not correctly installed

Signed-off-by: Simental Magana, Marcos <marcos.simental.magana@intel.com>