### PR TITLE
ciao-deploy: install `openstack-python-clients` bundle

### DIFF
--- a/ciao-deploy/Dockerfile
+++ b/ciao-deploy/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER marcos.simental.magana@intel.com
 ARG swupd_args
 ENV HOME=/root/
 
-RUN swupd bundle-add cryptography sysadmin-hostmgmt go-basic c-basic openstack-common $swupd_args
+RUN swupd bundle-add cryptography sysadmin-hostmgmt go-basic c-basic openstack-common openstack-python-clients $swupd_args
 
 RUN ansible-galaxy install -r /usr/share/ansible/examples/ciao/requirements.yml --ignore-certs
 


### PR DESCRIPTION
Base clearlinux image has changed and now openstack-common bundle
was refactored, this change removes `/usr/bin/openstack`, hence
`openstack-python-clients` bundle is needed in order to perform
operations using the openstack CLI.

Signed-off-by: Simental Magana, Marcos <marcos.simental.magana@intel.com>