### PR TITLE
ciao-deploy: update documentation to use privileged container

### DIFF
--- a/ciao-deploy/README.md
+++ b/ciao-deploy/README.md
@@ -36,7 +36,8 @@ documentation.
 Run the Ciao-deploy Container
 ----------------------------
 ```
-docker run -v $(pwd)/ciao:/root/ciao \
+docker run --privileged -v /dev/:/dev/ \
+    -v $(pwd)/ciao:/root/ciao \
     -it clearlinux/ciao-deploy
 
 ```
@@ -45,11 +46,19 @@ If you have setup your ssh key for the ansible setup, you may want to use it
 in your ciao-deploy container:
 
 ```
-docker run -v $(pwd)/ciao:/root/ciao \
+docker run --privileged -v /dev/:/dev/ \
+    -v $(pwd)/ciao:/root/ciao \
     -v /path/to/your/.ssh/key:/root/.ssh/key \
     -it clearlinux/ciao-deploy
 ```
 
+**Note**:
+
+The cotainer needs `–privileged -v /dev/:/dev/` in order to install
+your certificates in the
+[CNCI image](https://github.com/01org/ciao/tree/master/networking/ciao-cnci-agent#cnci-agent).
+To learn more about the Docker options used, please refer to the
+[Docker* documentation](https://docs.docker.com/engine/reference/commandline/run/).
 
 Extra Build ARGs
 ----------------


### PR DESCRIPTION
As the container use `/usr/bin/losetup` to manipulate the
CNCI image, it's neccessary to use the container in
`--privileged` mode and map `/dev/`, otherwise the container
won't be able to perfomr `losetup` operation nor mount the loops.

this commit updates the documentation to instruct the user how
to call the container in privileged mode.

This commit fixes #16

Signed-off-by: Simental Magana, Marcos <marcos.simental.magana@intel.com>