### PR TITLE
ciao-deploy: don't install roles from ansible galaxy

### DIFF
--- a/ciao-deploy/Dockerfile
+++ b/ciao-deploy/Dockerfile
@@ -5,9 +5,7 @@ ARG swupd_args
 ENV HOME=/root/
 
 RUN swupd update $swupd_args
-RUN swupd bundle-add cryptography sysadmin-hostmgmt go-basic c-basic openstack-common openstack-python-clients $swupd_args
-
-RUN ansible-galaxy install -r /usr/share/ansible/examples/ciao/requirements.yml --ignore-certs
+RUN swupd bundle-add cryptography sysadmin-hostmgmt go-basic c-basic openstack-python-clients $swupd_args
 
 RUN rm -rf /var/lib/swupd
 


### PR DESCRIPTION
This is a cleanup commit; since the documentation ask the user
to map the github.com/01org/ciao repository directly into the
ciao-deploy container, it's not neccessary to install the roles
from ansible-galaxy anymore due to those roles being used by
ansible directly from the ciao repo.

The `openstack-common` bundle is removed from the
`swupd bundle-add` command because the `openstack-python-clients`
bundle already includes it implicit.

This commit fixes #14

Signed-off-by: Simental Magana, Marcos <marcos.simental.magana@intel.com>