### PR TITLE
ciao-deploy: update readme to instruct user to use ssh key

### DIFF
--- a/ciao-deploy/README.md
+++ b/ciao-deploy/README.md
@@ -35,15 +35,9 @@ documentation.
 
 Run the Ciao-deploy Container
 ----------------------------
-```
-docker run --privileged -v /dev/:/dev/ \
-    -v $(pwd)/ciao:/root/ciao \
-    -it clearlinux/ciao-deploy
-
-```
-
-If you have setup your ssh key for the ansible setup, you may want to use it
-in your ciao-deploy container:
+You will need to use an ssh key to manage the remote nodes. Replace
+`/path/to/your/.ssh/key` with your private ssh key filename (notice it
+must be an absolute path).
 
 ```
 docker run --privileged -v /dev/:/dev/ \


### PR DESCRIPTION
README.md is ambiguous with 2 options of how to call the
ciao-deploy container (one with private ssh-key and other
without it), this may confuse the user.

This commit just mention 1 instruction to launch the
ciao-deploy container.

This commit fixes #15

Signed-off-by: Simental Magana, Marcos <marcos.simental.magana@intel.com>