### PR TITLE
updating 3 README files with Stack name change 

### DIFF
--- a/stacks/dlaas/README.md
+++ b/stacks/dlaas/README.md
@@ -1,5 +1,5 @@
-# Clear Linux Deep Learning Stack
+# Intel Deep Learning Stack
 
-This provides a Clear Linux Deep Learning Stack. To offer more flexibility, there are two versions of the Deep Learning Stack: Eigen optimized for Intel Architecture and a second version that includes Intel® Math Kernel Library for Deep Neural Networks (Intel® MKL-DNN) primitives.
+This provides the Intel® Deep Learning Stack. To offer more flexibility, there are two versions of the Deep Learning Stack: Eigen optimized for Intel Architecture and a second version that includes Intel® Math Kernel Library for Deep Neural Networks (Intel® MKL-DNN) primitives.
 
 Please see the folders in this level about the variants and how to build/use them.

--- a/stacks/dlaas/README.md
+++ b/stacks/dlaas/README.md
@@ -1,5 +1,5 @@
 # Intel Deep Learning Stack
 
-This provides the Intel® Deep Learning Stack. To offer more flexibility, there are two versions of the Deep Learning Stack: Eigen optimized for Intel Architecture and a second version that includes Intel® Math Kernel Library for Deep Neural Networks (Intel® MKL-DNN) primitives.
+This provides the Intel® Deep Learning As A Service Stack. To offer more flexibility, there are two versions of the Deep Learning Stack: Eigen optimized for Intel Architecture and a second version that includes Intel® Math Kernel Library for Deep Neural Networks (Intel® MKL-DNN) primitives.
 
 Please see the folders in this level about the variants and how to build/use them.

--- a/stacks/dlaas/mkl/README.md
+++ b/stacks/dlaas/mkl/README.md
@@ -1,7 +1,7 @@
-# Clear Linux Deep Learning Stack
+# Intel® Deep Learning Stack
 [![](https://images.microbadger.com/badges/image/clearlinux/dlaas-mkl.svg)](http://microbadger.com/images/clearlinux/dlaas-mkl "Get your own image badge on microbadger.com")
 
-This variant is built with Intel MKL DNN library
+This variant is built with Intel® MKL-DNN library
 
 # Building Locally
 

--- a/stacks/dlaas/mkl/README.md
+++ b/stacks/dlaas/mkl/README.md
@@ -1,4 +1,4 @@
-# Intel® Deep Learning Stack
+# Intel® Deep Learning As A Service Stack
 [![](https://images.microbadger.com/badges/image/clearlinux/dlaas-mkl.svg)](http://microbadger.com/images/clearlinux/dlaas-mkl "Get your own image badge on microbadger.com")
 
 This variant is built with Intel® MKL-DNN library

--- a/stacks/dlaas/oss/README.md
+++ b/stacks/dlaas/oss/README.md
@@ -1,4 +1,4 @@
-# Intel® Deep Learning Stack
+# Intel® Deep Learning As A Service Stack
 [![](https://images.microbadger.com/badges/image/clearlinux/dlaas.svg)](http://microbadger.com/images/clearlinux/dlaas "Get your own image badge on microbadger.com")
 
 This variant is built with Eigen

--- a/stacks/dlaas/oss/README.md
+++ b/stacks/dlaas/oss/README.md
@@ -1,4 +1,4 @@
-# Clear Linux Deep Learning Stack
+# Intel® Deep Learning Stack
 [![](https://images.microbadger.com/badges/image/clearlinux/dlaas.svg)](http://microbadger.com/images/clearlinux/dlaas "Get your own image badge on microbadger.com")
 
 This variant is built with Eigen


### PR DESCRIPTION
Changes name from Clear Linux Deep Learning Stack to Intel Deep Learning Stack in the README.md files. 