### PR TITLE
Removing links and add intel as the channel to download from

### DIFF
--- a/stacks/dlrs/mkl/setup_mkl.sh
+++ b/stacks/dlrs/mkl/setup_mkl.sh
@@ -13,9 +13,7 @@ mkdir -p /etc/profile.d && \
     source ~/.bashrc
 # create an env and install Tensorflow
 echo "Installing Tensorflow with MKL..."
-conda create -y  -n tf_env tensorflow nltk && \
-    echo "PATH=/opt/conda/envs/tf_env/bin:$PATH" >> ~/.bashrc && \
+conda create -y  -n tf_env tensorflow nltk -c intel && \
+    echo "export PATH=/opt/conda/envs/tf_env/bin:$PATH" >> ~/.bashrc && \
     echo "conda activate tf_env" >> ~/.bashrc
 ln -s -f /opt/conda/envs/tf_env/bin/python /usr/bin/python
-ln -s -f /opt/conda/envs/tf_env/lib/python3.6/site-packages /opt/conda/lib/python3.7/site-packages
-source ~/.bashrc


### PR DESCRIPTION
Two changes to the mkl dockerfiles
- Change channel to intel for tensorflow
- Remove sym links that are not required
Closes: #56 