### PR TITLE
switching to official anaconda channel

### DIFF
--- a/stacks/dlrs/mkl/setup_mkl.sh
+++ b/stacks/dlrs/mkl/setup_mkl.sh
@@ -13,7 +13,7 @@ mkdir -p /etc/profile.d && \
     source ~/.bashrc
 # create an env and install Tensorflow
 echo "Installing Tensorflow with MKL..."
-conda create -y  -n tf_env tensorflow nltk -c intel && \
+conda create -y -n tf_env tensorflow nltk && \
     echo "export PATH=/opt/conda/envs/tf_env/bin:$PATH" >> ~/.bashrc && \
     echo "conda activate tf_env" >> ~/.bashrc
 ln -s -f /opt/conda/envs/tf_env/bin/python /usr/bin/python


### PR DESCRIPTION
There is a perf regression for Tensorflow from intel channel, switching to anaconda channel for TF.
Closes: #62