### PR TITLE
Using latest validated Clear Linux OS version in Dockerfiles

### DIFF
--- a/stacks/dlrs/mkl/Dockerfile
+++ b/stacks/dlrs/mkl/Dockerfile
@@ -1,5 +1,5 @@
 FROM clearlinux
-MAINTAINER otc-swstacks@intel.com
+LABEL maintainer="otc-swstacks@intel.com"
 
 ARG swupd_args
 

--- a/stacks/dlrs/mkl/README.md
+++ b/stacks/dlrs/mkl/README.md
@@ -7,9 +7,10 @@
 Default build args in Docker are on: https://docs.docker.com/engine/reference/builder/#arg
 
 ```
-docker build --no-cache -t clearlinux/stacks-dlrs-mkl .
+docker build --no-cache -t clearlinux/stacks-dlrs-mkl --build-arg swupd_args="-m 26700" .
 ```
 
-### Optional Build ARGs
+### Build ARGs
 
 * `swupd_args` specifies [swupd update](https://clearlinux.org/documentation/clear-linux/guides/maintenance/swupd-guide#perform-a-manual-update) flags passed to the update during build.
+NOTE: `swupd_args` defaults so that the Clear Linux OS version is updated to 26700. Upgrading to a later version is not recommended, as further versions have not been validated.

--- a/stacks/dlrs/oss/Dockerfile
+++ b/stacks/dlrs/oss/Dockerfile
@@ -1,5 +1,5 @@
 FROM clearlinux
-MAINTAINER otc-swstacks@intel.com
+LABEL maintainer="otc-swstacks@intel.com"
 
 ARG swupd_args
 

--- a/stacks/dlrs/oss/README.md
+++ b/stacks/dlrs/oss/README.md
@@ -7,9 +7,10 @@
 Default build args in Docker are on: https://docs.docker.com/engine/reference/builder/#arg
 
 ```
-docker build --no-cache -t clearlinux/stacks-dlrs-oss .
+docker build --no-cache -t clearlinux/stacks-dlrs-oss --build-arg swupd_args="-m 26700" .
 ```
 
 ### Optional Build ARGs
 
 * `swupd_args` specifies [swupd update](https://clearlinux.org/documentation/clear-linux/guides/maintenance/swupd-guide#perform-a-manual-update) flags passed to the update during build.
+NOTE: `swupd_args` defaults so that the Clear Linux OS version is updated to 26700. Upgrading to a later version is not recommended, as further versions have not been validated.

--- a/stacks/dlrs/releasenote.md
+++ b/stacks/dlrs/releasenote.md
@@ -12,7 +12,7 @@ The Deep Learning Reference Stack, an integrated, highly-performant open source 
 To offer more flexibility, we are releasing two versions of the Deep Learning Reference Stack:  a version that includes TensorFlow* optimized for Intel® Architecture, the "Eigen" version, and a second version that includes the TensorFlow* framework optimized using Intel® Math Kernel Library for Deep Neural Networks, the "Intel® MKL-DNN" version.
 
 > **Note:**
-     Clear Linux will be automatically updated to the latest release in the container.  The minimum validated version of Clear Linux for this stack is 26240
+     Clear Linux will be automatically updated to release version 26700 in the container.  The minimum validated version of Clear Linux for this stack is 26240
 
 > **Note:**
 > For multi-node support, we include a registry with a set of jsonnet files to show integration with Kubeflow for deployment.
@@ -45,7 +45,7 @@ The official Deep Learning Reference Stack Docker images are hosted at: https://
  * Pull from the [Intel MKL-DNN version](https://hub.docker.com/r/clearlinux/stacks-dlrs-mkl/)
 
 > **Note:**
-   The OSS version of the image will use the latest version of Clear Linux.
+   The OSS version of the image will use version 26700 of Clear Linux.
 
 ## Licensing
 


### PR DESCRIPTION
The stacks team validates a certain Clear Linux OS version, to ensure functionality, such version must be provided and used within the Dockerfiles. The releasenotes and readme files should also reflect the change.

Fixes #65 