### PR TITLE
prototypes: sets up ks prototypes to receive image names as parameter

### DIFF
--- a/stacks/dlrs/kubeflow/dlrs-tfjob/dlrs-bench/prototypes/dlrs-alexnet.jsonnet
+++ b/stacks/dlrs/kubeflow/dlrs-tfjob/dlrs-bench/prototypes/dlrs-alexnet.jsonnet
@@ -3,16 +3,17 @@
 // @description dlrs multi-node benchmark
 // @shortDescription A multi-node DLaaS benchmark
 // @param name string Name for the job.
+// @param image string DLRS Image name.
 
 local k = import "k.libsonnet";
 
 local name = params.name;
 local namespace = env.namespace;
-local image = "hub.docker.com/clearlinux/stacks-dlrs-kubeflow:latest";
+local image = params.image;
 local replicas = 3;
 
 local tfjob = {
-  apiVersion: "kubeflow.org/v1alpha2",
+  apiVersion: "kubeflow.org/v1beta1",
   kind: "TFJob",
   metadata: {
     name: name,

--- a/stacks/dlrs/kubeflow/dlrs-tfjob/dlrs-bench/prototypes/dlrs-resnet50.jsonnet
+++ b/stacks/dlrs/kubeflow/dlrs-tfjob/dlrs-bench/prototypes/dlrs-resnet50.jsonnet
@@ -3,16 +3,17 @@
 // @description dlrs multi-node benchmark
 // @shortDescription A multi-node DLaaS benchmark
 // @param name string Name for the job.
+// @param image string DLRS Image name.
 
 local k = import "k.libsonnet";
 
 local name = params.name;
 local namespace = env.namespace;
-local image = "hub.docker.com/clearlinux/stacks-dlrs-kubeflow:latest";
+local image = params.image;
 local replicas = 3;
 
 local tfjob = {
-  apiVersion: "kubeflow.org/v1alpha2",
+  apiVersion: "kubeflow.org/v1beta1",
   kind: "TFJob",
   metadata: {
     name: name,


### PR DESCRIPTION
The image name was hardcoded. We should receive a variable with the
image name instead, this will let the end user select which DLRS
flavour (mkl or oss) to use.

Signed-off-by: Daniela Plascencia <daniela.plascencia@linux.intel.com>