### PR TITLE
Cleanup miniconda caches after environment is created

### DIFF
--- a/stacks/dlrs/mkl/setup_mkl.sh
+++ b/stacks/dlrs/mkl/setup_mkl.sh
@@ -13,7 +13,7 @@ mkdir -p /etc/profile.d && \
     source ~/.bashrc
 # create an env and install Tensorflow
 echo "Installing Tensorflow with MKL..."
-conda create -y -n tf_env tensorflow nltk && \
+conda create -y -n tf_env tensorflow nltk && conda clean --all -y && \
     echo "export PATH=/opt/conda/envs/tf_env/bin:$PATH" >> ~/.bashrc && \
     echo "conda activate tf_env" >> ~/.bashrc
 ln -s -f /opt/conda/envs/tf_env/bin/python /usr/bin/python


### PR DESCRIPTION
There is no sense to ship caches and downloaded archives in the container.
Cleaning it will save about 500Mb