### PR TITLE
Fix some hyperlinks

### DIFF
--- a/cgit/README.md
+++ b/cgit/README.md
@@ -22,6 +22,6 @@ docker run -p 80:80 -v <git repo path>:/var/www/cgit clearlinux/cgit
 
 Extra Build ARGs
 ----------------
-- ``swupd_args`` Specifies [SWUPD](https://clearlinux.org/documentation/swupdate_how_to_run_the_updater.html) flags
+- ``swupd_args`` Specifies [SWUPD](https://github.com/clearlinux/swupd-client/blob/master/docs/swupd.1.rst#options) flags
 
 Default build args in Docker are on: https://docs.docker.com/engine/reference/builder/#arg

--- a/clr-sdk/README.md
+++ b/clr-sdk/README.md
@@ -35,7 +35,7 @@ docker build -t clearlinux/clr-sdk .
 > configure your proxy.
 
 #### Optional Build ARGs
-* `--build-arg swupd_args` specifies [SWUPD](https://clearlinux.org/documentation/swupdate_how_to_run_the_updater.html) flags passed to the update during build.
+* `--build-arg swupd_args` specifies [SWUPD](https://github.com/clearlinux/swupd-client/blob/master/docs/swupd.1.rst#options) flags passed to the update during build.
 ## Pulling from Dockerhub
 ```
 docker pull clearlinux/clr-sdk

--- a/elasticsearch/README.md
+++ b/elasticsearch/README.md
@@ -53,6 +53,6 @@ Please refer to [page](https://www.elastic.co/guide/en/elasticsearch/reference/5
 
 Extra Build ARGs
 ----------------
-- ``swupd_args`` Specifies [SWUPD](https://clearlinux.org/documentation/swupdate_how_to_run_the_updater.html) flags
+- ``swupd_args`` Specifies [SWUPD](https://github.com/clearlinux/swupd-client/blob/master/docs/swupd.1.rst#options) flags
 
 Default build args in Docker are on: https://docs.docker.com/engine/reference/builder/#arg

--- a/httpd/README.md
+++ b/httpd/README.md
@@ -52,6 +52,6 @@ docker run --name some-httpd -dit -p 8080:80 \
 
 Extra Build ARGs
 ----------------
-- ``swupd_args`` Specifies [SWUPD](https://clearlinux.org/documentation/swupdate_how_to_run_the_updater.html) flags
+- ``swupd_args`` Specifies [SWUPD](https://github.com/clearlinux/swupd-client/blob/master/docs/swupd.1.rst#options) flags
 
 Default build args in Docker are on: https://docs.docker.com/engine/reference/builder/#arg

--- a/machine-learning-ui/README.md
+++ b/machine-learning-ui/README.md
@@ -30,6 +30,6 @@ none
 
 Extra Build ARGs
 ----------------
-- ``swupd_args`` Specifies [SWUPD](https://clearlinux.org/documentation/swupdate_how_to_run_the_updater.html) flags
+- ``swupd_args`` Specifies [SWUPD](https://github.com/clearlinux/swupd-client/blob/master/docs/swupd.1.rst#options) flags
 
 Default build args in Docker are on: https://docs.docker.com/engine/reference/builder/#/arg

--- a/machine-learning-ui/README.md
+++ b/machine-learning-ui/README.md
@@ -32,4 +32,4 @@ Extra Build ARGs
 ----------------
 - ``swupd_args`` Specifies [SWUPD](https://github.com/clearlinux/swupd-client/blob/master/docs/swupd.1.rst#options) flags
 
-Default build args in Docker are on: https://docs.docker.com/engine/reference/builder/#/arg
+Default build args in Docker are on: https://docs.docker.com/engine/reference/builder/#arg

--- a/machine-learning/README.md
+++ b/machine-learning/README.md
@@ -30,6 +30,6 @@ none
 
 Extra Build ARGs
 ----------------
-- ``swupd_args`` Specifies [SWUPD](https://clearlinux.org/documentation/swupdate_how_to_run_the_updater.html) flags
+- ``swupd_args`` Specifies [SWUPD](https://github.com/clearlinux/swupd-client/blob/master/docs/swupd.1.rst#options) flags
 
 Default build args in Docker are on: https://docs.docker.com/engine/reference/builder/#/arg

--- a/machine-learning/README.md
+++ b/machine-learning/README.md
@@ -32,4 +32,4 @@ Extra Build ARGs
 ----------------
 - ``swupd_args`` Specifies [SWUPD](https://github.com/clearlinux/swupd-client/blob/master/docs/swupd.1.rst#options) flags
 
-Default build args in Docker are on: https://docs.docker.com/engine/reference/builder/#/arg
+Default build args in Docker are on: https://docs.docker.com/engine/reference/builder/#arg

--- a/mariadb/README.md
+++ b/mariadb/README.md
@@ -32,6 +32,6 @@ Environment Variables
 
 Extra Build ARGs
 ----------------
-- ``swupd_args`` Specifies [SWUPD](https://clearlinux.org/documentation/swupdate_how_to_run_the_updater.html) flags
+- ``swupd_args`` Specifies [SWUPD](https://github.com/clearlinux/swupd-client/blob/master/docs/swupd.1.rst#options) flags
 
 Default build args in Docker are on: https://docs.docker.com/engine/reference/builder/#/arg

--- a/mariadb/README.md
+++ b/mariadb/README.md
@@ -34,4 +34,4 @@ Extra Build ARGs
 ----------------
 - ``swupd_args`` Specifies [SWUPD](https://github.com/clearlinux/swupd-client/blob/master/docs/swupd.1.rst#options) flags
 
-Default build args in Docker are on: https://docs.docker.com/engine/reference/builder/#/arg
+Default build args in Docker are on: https://docs.docker.com/engine/reference/builder/#arg

--- a/memcached/README.md
+++ b/memcached/README.md
@@ -31,6 +31,6 @@ docker run --rm --network somenetwork redislabs/memtier_benchmark ./memtier_benc
 
 Extra Build ARGs
 ----------------
-- ``swupd_args`` Specifies [SWUPD](https://clearlinux.org/documentation/swupdate_how_to_run_the_updater.html) flags
+- ``swupd_args`` Specifies [SWUPD](https://github.com/clearlinux/swupd-client/blob/master/docs/swupd.1.rst#options) flags
 
 Default build args in Docker are on: https://docs.docker.com/engine/reference/builder/#arg

--- a/nginx/README.md
+++ b/nginx/README.md
@@ -26,6 +26,6 @@ How to use this image
 
 Extra Build ARGs
 ----------------
-- ``swupd_args`` Specifies [SWUPD](https://clearlinux.org/documentation/swupdate_how_to_run_the_updater.html) flags
+- ``swupd_args`` Specifies [SWUPD](https://github.com/clearlinux/swupd-client/blob/master/docs/swupd.1.rst#options) flags
 
 Default build args in Docker are on: https://docs.docker.com/engine/reference/builder/#arg

--- a/postgres/README.md
+++ b/postgres/README.md
@@ -26,6 +26,6 @@ Environment Variables
 
 Extra Build ARGs
 ----------------
-- ``swupd_args`` Specifies [SWUPD](https://clearlinux.org/documentation/swupdate_how_to_run_the_updater.html) flags
+- ``swupd_args`` Specifies [SWUPD](https://github.com/clearlinux/swupd-client/blob/master/docs/swupd.1.rst#options) flags
 
 Default build args in Docker are on: https://docs.docker.com/engine/reference/builder/#arg

--- a/python/README.md
+++ b/python/README.md
@@ -26,6 +26,6 @@ How to use this image
 
 Extra Build ARGs
 ----------------
-- ``swupd_args`` Specifies [SWUPD](https://clearlinux.org/documentation/swupdate_how_to_run_the_updater.html) flags
+- ``swupd_args`` Specifies [SWUPD](https://github.com/clearlinux/swupd-client/blob/master/docs/swupd.1.rst#options) flags
 
 Default build args in Docker are on: https://docs.docker.com/engine/reference/builder/#arg

--- a/redis/README.md
+++ b/redis/README.md
@@ -38,6 +38,6 @@ Please refer to the official redis image [page](https://hub.docker.com/_/redis).
 
 Extra Build ARGs
 ----------------
-- ``swupd_args`` Specifies [SWUPD](https://clearlinux.org/documentation/swupdate_how_to_run_the_updater.html) flags
+- ``swupd_args`` Specifies [SWUPD](https://github.com/clearlinux/swupd-client/blob/master/docs/swupd.1.rst#options) flags
 
 Default build args in Docker are on: https://docs.docker.com/engine/reference/builder/#arg

--- a/stacks/dlrs/mkl/README.md
+++ b/stacks/dlrs/mkl/README.md
@@ -12,6 +12,6 @@ docker build --no-cache -t clearlinux/stacks-dlrs-mkl .
 
 ### Build ARGs
 
-* `swupd_args` specifies [swupd update](https://clearlinux.org/documentation/clear-linux/guides/maintenance/swupd-guide#perform-a-manual-update) flags passed to the update during build.
+* `swupd_args` specifies [swupd update](https://github.com/clearlinux/swupd-client/blob/master/docs/swupd.1.rst#options) flags passed to the update during build.
 
 >NOTE: An empty `swupd_args` will default to Clear Linux OS latest version. Consider this when building from the Dockerfile, as an OS update will be performed. The docker image in this registry was built and validated using version 28560.

--- a/stacks/dlrs/oss/README.md
+++ b/stacks/dlrs/oss/README.md
@@ -12,6 +12,6 @@ docker build --no-cache -t clearlinux/stacks-dlrs-oss .
 
 ### Optional Build ARGs
 
-* `swupd_args` specifies [swupd update](https://clearlinux.org/documentation/clear-linux/guides/maintenance/swupd-guide#perform-a-manual-update) flags passed to the update during build.
+* `swupd_args` specifies [swupd update](https://github.com/clearlinux/swupd-client/blob/master/docs/swupd.1.rst#options) flags passed to the update during build.
 
 >NOTE: An empty `swupd_args` will default to Clear Linux OS latest version. Consider this when building from the Dockerfile, as an OS update will be performed. The docker image in this registry was built and validated using version 28560.

--- a/stacks/dlrs/pytorch/mkl/README.md
+++ b/stacks/dlrs/pytorch/mkl/README.md
@@ -12,6 +12,6 @@ docker build --no-cache -t clearlinux/stacks-pytorch-mkl .
 
 ### Build ARGs
 
-* `swupd_args` specifies [swupd update](https://clearlinux.org/documentation/clear-linux/guides/maintenance/swupd-guide#perform-a-manual-update) flags passed to the update during build.
+* `swupd_args` specifies [swupd update](https://github.com/clearlinux/swupd-client/blob/master/docs/swupd.1.rst#options) flags passed to the update during build.
 
 >NOTE: An empty `swupd_args` will default to Clear Linux OS latest version. Consider this when building from the Dockerfile, as an OS update will be performed. The docker image in this registry was built and validated using version 28560.

--- a/stacks/dlrs/pytorch/oss/README.md
+++ b/stacks/dlrs/pytorch/oss/README.md
@@ -12,6 +12,6 @@ docker build --no-cache -t clearlinux/stacks-pytorch-oss .
 
 ### Optional Build ARGs
 
-* `swupd_args` specifies [swupd update](https://clearlinux.org/documentation/clear-linux/guides/maintenance/swupd-guide#perform-a-manual-update) flags passed to the update during build.
+* `swupd_args` specifies [swupd update](https://github.com/clearlinux/swupd-client/blob/master/docs/swupd.1.rst#options) flags passed to the update during build.
 
 >NOTE: An empty `swupd_args` will default to Clear Linux OS latest version. Consider this when building from the Dockerfile, as an OS update will be performed. The docker image in this registry was built and validated using version 28560.


### PR DESCRIPTION
There are some broken links in the various `README.md` files, and some of the links point to clearlinux.org when they can instead point directly to the swupd-client github repo for the latest information. This PR addresses these issues.