### PR TITLE
Remove image list from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,20 +4,3 @@ Clear Linux* based Docker Containers
 
 This repository holds all the Dockerfiles for Clear Linux based containers that are hosted at:
 https://hub.docker.com/u/clearlinux/
-
-Containers
-----------
-- clr-sdk
-- elasticsearch
-- httpd
-- machine-learning
-- mixer-ci
-- Keystone
-- MariaDB
-- memcached
-- redis
-- python
-- stacks-dlrs-oss
-- stacks-dlrs-mkl
-- stacks-pytorch-oss
-- stacks-pytorch-mkl


### PR DESCRIPTION
Browsing through the folder directory structure is always a current
means to identify which images are being published on Docker Hub.  Would
no longer need to keep another list in sync.

Signed-off-by: George T Kramer <george.t.kramer@intel.com>