### PR TITLE
Do not update boot with swupd

### DIFF
--- a/cgit/Dockerfile
+++ b/cgit/Dockerfile
@@ -1,6 +1,6 @@
 FROM clearlinux/httpd
 
-ARG swupd_args
+ARG swupd_args="--no-boot-update $swupd_args"
 RUN swupd update $swupd_args
 RUN swupd bundle-add sudo curl scm-server $swupd_args
 RUN rm -rf /var/lib/swupd

--- a/clr-sdk/Dockerfile
+++ b/clr-sdk/Dockerfile
@@ -1,7 +1,7 @@
 FROM clearlinux:latest
 MAINTAINER kevin.c.wells@intel.com
 
-ARG swupd_args
+ARG swupd_args="--no-boot-update $swupd_args"
 
 COPY setup.py /usr/bin/setup.py
 

--- a/elasticsearch/Dockerfile
+++ b/elasticsearch/Dockerfile
@@ -1,7 +1,7 @@
 FROM clearlinux:latest
 MAINTAINER qi.zheng@intel.com
 
-ARG swupd_args
+ARG swupd_args="--no-boot-update $swupd_args"
 
 RUN swupd update $swupd_args \
 	&& swupd bundle-add elasticsearch $swupd_args \

--- a/httpd/Dockerfile
+++ b/httpd/Dockerfile
@@ -1,7 +1,7 @@
 FROM clearlinux:latest
 MAINTAINER qi.zheng@intel.com
 
-ARG swupd_args
+ARG swupd_args="--no-boot-update $swupd_args"
 
 RUN swupd update $swupd_args \
 	&& swupd bundle-add httpd $swupd_args \

--- a/machine-learning-ui/Dockerfile
+++ b/machine-learning-ui/Dockerfile
@@ -1,7 +1,7 @@
 FROM clearlinux
 MAINTAINER william.douglas@intel.com
 
-ARG swupd_args
+ARG swupd_args="--no-boot-update $swupd_args"
 
 RUN swupd update $swupd_args
 RUN swupd bundle-add machine-learning-web-ui

--- a/machine-learning/Dockerfile
+++ b/machine-learning/Dockerfile
@@ -1,7 +1,7 @@
 FROM clearlinux
 MAINTAINER marcos.simental.magana@intel.com
 
-ARG swupd_args
+ARG swupd_args="--no-boot-update $swupd_args"
 
 RUN swupd update $swupd_args
 RUN swupd bundle-add machine-learning-basic R-basic R-extras

--- a/mariadb/Dockerfile
+++ b/mariadb/Dockerfile
@@ -1,7 +1,7 @@
 FROM clearlinux:latest
 MAINTAINER qi.zheng@intel.com
 
-ARG swupd_args
+ARG swupd_args="--no-boot-update $swupd_args"
 
 RUN swupd update $swupd_args \
 	&& swupd bundle-add mariadb $swupd_args \

--- a/memcached/Dockerfile
+++ b/memcached/Dockerfile
@@ -1,7 +1,7 @@
 FROM clearlinux:latest
 MAINTAINER qi.zheng@intel.com
 
-ARG swupd_args
+ARG swupd_args="--no-boot-update $swupd_args"
 
 RUN swupd update $swupd_args \
 	&& swupd bundle-add memcached $swupd_args \

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,7 +1,7 @@
 FROM clearlinux:latest
 MAINTAINER bin.yang@intel.com
 
-ARG swupd_args
+ARG swupd_args="--no-boot-update $swupd_args"
 
 COPY default.conf /etc/nginx/conf.d/default.conf
 

--- a/php/Dockerfile
+++ b/php/Dockerfile
@@ -1,7 +1,7 @@
 FROM clearlinux:latest
 MAINTAINER jianjun.liu@intel.com
 
-ARG swupd_args
+ARG swupd_args="--no-boot-update $swupd_args"
 
 RUN swupd update $swupd_args \
 	&& swupd bundle-add php-basic $swupd_args \

--- a/redis/Dockerfile
+++ b/redis/Dockerfile
@@ -1,7 +1,7 @@
 FROM clearlinux:latest
 MAINTAINER qi.zheng@intel.com
 
-ARG swupd_args
+ARG swupd_args="--no-boot-update $swupd_args"
 
 RUN swupd update $swupd_args \
 	&& swupd bundle-add redis-native $swupd_args \

--- a/stacks/dlrs/mkl/Dockerfile
+++ b/stacks/dlrs/mkl/Dockerfile
@@ -7,7 +7,7 @@ LABEL maintainer=otc-swstacks@intel.com
 
 # tf with vnni support and bug fixes
 ARG TF_COMMIT_SHA=47ab68d265a96b6e7be06afd1b4b47e0114c0ee9
-ARG swupd_args
+ARG swupd_args="--no-boot-update $swupd_args"
 
 # update os and add required bundles
 RUN swupd update $swupd_args && \
@@ -62,7 +62,7 @@ FROM clearlinux
 LABEL maintainer=otc-swstacks@intel.com
 
 ARG HOROVOD_VERSION=0.16.1
-ARG swupd_args
+ARG swupd_args="--no-boot-update $swupd_args"
 
 # update os and add required bundles
 RUN swupd update $swupd_args && \

--- a/stacks/dlrs/oss/Dockerfile
+++ b/stacks/dlrs/oss/Dockerfile
@@ -1,7 +1,7 @@
 FROM clearlinux
 MAINTAINER otc-swstacks@intel.com
 
-ARG swupd_args
+ARG swupd_args="--no-boot-update $swupd_args"
 
 RUN swupd update $swupd_args && \
 		swupd bundle-add curl sysadmin-basic \

--- a/stacks/dlrs/pytorch/mkl/Dockerfile
+++ b/stacks/dlrs/pytorch/mkl/Dockerfile
@@ -4,7 +4,7 @@ LABEL maintainer=otc-swstacks@intel.com
 
 ARG PYTHON_VERSION=3.7.1
 ARG MINICONDA_VERSION=4.5.12
-ARG swupd_args
+ARG swupd_args="--no-boot-update $swupd_args"
 ENV PATH /opt/conda/bin:$PATH
 
 # update os and add pkgs

--- a/stacks/dlrs/pytorch/oss/Dockerfile
+++ b/stacks/dlrs/pytorch/oss/Dockerfile
@@ -2,7 +2,7 @@
 FROM clearlinux
 LABEL maintainer=otc-swstacks@intel.com
 
-ARG swupd_args
+ARG swupd_args="--no-boot-update $swupd_args"
 
 # update os and install pytorch
 RUN swupd update $swupd_args && \


### PR DESCRIPTION
When running swupd in a Docker image, there will be no kernels for CBM
to attempt to configure for booting.

Signed-off-by: George T Kramer <george.t.kramer@intel.com>