### PR TITLE
Make the swupd update always be the layer two

### DIFF
--- a/cgit/Dockerfile
+++ b/cgit/Dockerfile
@@ -1,9 +1,9 @@
 FROM clearlinux/httpd
 
 ARG swupd_args
-RUN swupd update $swupd_args
-RUN swupd bundle-add sudo curl scm-server $swupd_args
-RUN rm -rf /var/lib/swupd
+RUN swupd update --no-boot-update $swupd_args
+RUN swupd bundle-add sudo curl scm-server $swupd_args \
+	&& rm -rf /var/lib/swupd/*
 
 COPY cgitrc /etc/cgitrc
 COPY httpd-cgit.conf /etc/httpd/conf.d/httpd-cgit.conf

--- a/elasticsearch/Dockerfile
+++ b/elasticsearch/Dockerfile
@@ -3,8 +3,8 @@ MAINTAINER qi.zheng@intel.com
 
 ARG swupd_args
 
-RUN swupd update $swupd_args \
-	&& swupd bundle-add elasticsearch $swupd_args \
+RUN swupd update --no-boot-update $swupd_args
+RUN swupd bundle-add elasticsearch $swupd_args \
 	&& rm -rf /var/lib/swupd/*
 
 RUN set -ex \

--- a/haproxy/Dockerfile
+++ b/haproxy/Dockerfile
@@ -6,7 +6,7 @@ ARG swupd_args
 RUN swupd update --no-boot-update $swupd_args
 
 RUN swupd bundle-add haproxy $swupd_args \
-    && rm -rf /var/lib/swupd \
+    && rm -rf /var/lib/swupd/* \
     && mkdir -p /usr/local/etc/haproxy
 
 STOPSIGNAL SIGUSR1

--- a/httpd/Dockerfile
+++ b/httpd/Dockerfile
@@ -3,8 +3,8 @@ MAINTAINER qi.zheng@intel.com
 
 ARG swupd_args
 
-RUN swupd update $swupd_args \
-	&& swupd bundle-add httpd $swupd_args \
+RUN swupd update --no-boot-update $swupd_args
+RUN swupd bundle-add httpd $swupd_args \
 	&& rm -rf /var/lib/swupd/*
 
 #default configuration on /usr/share/defaults/httpd/httpd.conf

--- a/iperf/Dockerfile
+++ b/iperf/Dockerfile
@@ -3,8 +3,9 @@ MAINTAINER long1.wang@intel.com
 
 ARG swupd_args
 
-RUN swupd update --no-boot-update $swupd_args && \
-    swupd bundle-add iperf $swupd_args
+RUN swupd update --no-boot-update $swupd_args
+RUN swupd bundle-add iperf $swupd_args \
+	&& rm -rf /var/lib/swupd/*
 
 # Define default command
 ENTRYPOINT ["iperf3"]

--- a/mariadb/Dockerfile
+++ b/mariadb/Dockerfile
@@ -3,8 +3,8 @@ MAINTAINER qi.zheng@intel.com
 
 ARG swupd_args
 
-RUN swupd update $swupd_args \
-	&& swupd bundle-add mariadb $swupd_args \
+RUN swupd update --no-boot-update $swupd_args
+RUN swupd bundle-add mariadb $swupd_args \
 	&& rm -rf /var/lib/swupd/*
 
 RUN mkdir /docker-entrypoint-initdb.d

--- a/memcached/Dockerfile
+++ b/memcached/Dockerfile
@@ -3,8 +3,8 @@ MAINTAINER qi.zheng@intel.com
 
 ARG swupd_args
 
-RUN swupd update $swupd_args \
-	&& swupd bundle-add memcached $swupd_args \
+RUN swupd update --no-boot-update $swupd_args
+RUN swupd bundle-add memcached $swupd_args \
 	&& rm -rf /var/lib/swupd/*
 
 COPY docker-entrypoint.sh /usr/local/bin/

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -3,11 +3,12 @@ MAINTAINER bin.yang@intel.com
 
 ARG swupd_args
 
+RUN swupd update --no-boot-update $swupd_args
+
 COPY default.conf /etc/nginx/conf.d/default.conf
 
-RUN swupd update --no-boot-update $swupd_args && \
-    swupd bundle-add nginx $swupd_args && \
-    rm -rf /var/lib/swupd && \
+RUN swupd bundle-add nginx $swupd_args && \
+    rm -rf /var/lib/swupd/* && \
     mkdir -p /var/log/nginx && \
     # forward request and error logs to docker log collector
     ln -sf /dev/stdout /var/log/nginx/access.log && \

--- a/node/Dockerfile
+++ b/node/Dockerfile
@@ -3,10 +3,8 @@ MAINTAINER jianjun.liu@intel.com
 
 ARG swupd_args
 
-RUN swupd update $swupd_args \
-	&& swupd bundle-add nodejs-basic $swupd_args \
+RUN swupd update --no-boot-update $swupd_args
+RUN swupd bundle-add nodejs-basic $swupd_args \
 	&& rm -rf /var/lib/swupd/*
-
-RUN /usr/bin/ldconfig
 
 CMD ["node"]

--- a/openjdk/Dockerfile
+++ b/openjdk/Dockerfile
@@ -3,8 +3,8 @@ MAINTAINER long1.wang@intel.com
 
 ARG swupd_args
 
-RUN swupd update --no-boot-update $swupd_args && \
-    swupd bundle-add java-runtime $swupd_args && \
-    rm -rf /var/lib/swupd
+RUN swupd update --no-boot-update $swupd_args
+RUN swupd bundle-add java-runtime $swupd_args && \
+    rm -rf /var/lib/swupd/*
 
 CMD ["java"]

--- a/php/Dockerfile
+++ b/php/Dockerfile
@@ -3,8 +3,8 @@ MAINTAINER jianjun.liu@intel.com
 
 ARG swupd_args
 
-RUN swupd update $swupd_args \
-	&& swupd bundle-add php-basic $swupd_args \
+RUN swupd update --no-boot-update $swupd_args
+RUN swupd bundle-add php-basic $swupd_args \
 	&& rm -rf /var/lib/swupd/*
 
 CMD ["php","-a"]

--- a/postgres/Dockerfile
+++ b/postgres/Dockerfile
@@ -1,8 +1,11 @@
 FROM clearlinux:latest
 MAINTAINER william.douglas@intel.com
 
-RUN swupd update $swupd_args && \
-    swupd bundle-add postgresql $swupd_args
+ARG swupd_args
+
+RUN swupd update --no-boot-update $swupd_args
+RUN swupd bundle-add postgresql $swupd_args \
+	&& rm -rf /var/lib/swupd/*
 
 ENV PGDATA /var/lib/pgsql/data
 RUN mkdir -p /run/postgresql && chown -R postgres:postgres /run/postgresql

--- a/python/Dockerfile
+++ b/python/Dockerfile
@@ -1,8 +1,10 @@
 FROM clearlinux:latest
 MAINTAINER hongzhan.chen@intel.com
 
-RUN swupd update $swupd_args && \
-    swupd bundle-add python3-basic $swupd_args
-RUN rm -rf /var/lib/swupd
+ARG swupd_args
+
+RUN swupd update --no-boot-update $swupd_args
+RUN swupd bundle-add python3-basic $swupd_args \
+	&& rm -rf /var/lib/swupd/*
 
 CMD ["python3"]

--- a/redis/Dockerfile
+++ b/redis/Dockerfile
@@ -3,8 +3,8 @@ MAINTAINER qi.zheng@intel.com
 
 ARG swupd_args
 
-RUN swupd update $swupd_args \
-	&& swupd bundle-add redis-native $swupd_args \
+RUN swupd update --no-boot-update $swupd_args
+RUN swupd bundle-add redis-native $swupd_args \
 	&& rm -rf /var/lib/swupd/* \
 	&& mkdir /data && chown redis:redis /data
 

--- a/ruby/Dockerfile
+++ b/ruby/Dockerfile
@@ -1,8 +1,8 @@
 FROM clearlinux:latest
 MAINTAINER hongzhan.chen@intel.com
 
-RUN swupd update --no-boot-update $swupd_args && \
-    swupd bundle-add ruby-basic $swupd_args
-RUN rm -rf /var/lib/swupd
+RUN swupd update --no-boot-update $swupd_args
+RUN swupd bundle-add ruby-basic $swupd_args \
+	&& rm -rf /var/lib/swupd/*
 
 CMD ["irb"]


### PR DESCRIPTION
To help analyze the container image size by layers, assume
each container image be comprised of:
Layer 1: clearlinux:latest
Layer 2: swupd update
Other layers: the container configurations

With this, we can continue to optimize layer size accordingly.

Signed-off-by: Qi Zheng <qi.zheng@intel.com>