### PR TITLE
clr-installer-ci: update bundles

### DIFF
--- a/clr-installer-ci/Dockerfile
+++ b/clr-installer-ci/Dockerfile
@@ -6,7 +6,8 @@ ENV GOPATH="/go" PATH="/go/bin:${PATH}"
 
 # Update and add bundles
 RUN swupd update && \
-    swupd bundle-add sysadmin-basic storage-utils network-basic go-basic-dev git telemetrics os-installer && \
+    swupd bundle-add sysadmin-basic storage-utils network-basic go-basic-dev clr-installer-gui && \
+    swupd clean && \
     # Install the Go Linters
     go get -u gopkg.in/alecthomas/gometalinter.v2 && \
     gometalinter.v2 --install


### PR DESCRIPTION
We were still using the older ister bundle to install dependencies and then augmenting during the TravisCI run.
