### PR TITLE
clr-installer-ci: Add the GTK development support

### DIFF
--- a/clr-installer-ci/Dockerfile
+++ b/clr-installer-ci/Dockerfile
@@ -6,7 +6,7 @@ ENV GOPATH="/go" PATH="/go/bin:${PATH}"
 
 # Update and add bundles
 RUN swupd update && \
-    swupd bundle-add sysadmin-basic storage-utils network-basic go-basic-dev clr-installer-gui && \
+    swupd bundle-add sysadmin-basic storage-utils network-basic go-basic-dev devpkg-gtk3 clr-installer-gui && \
     swupd clean && \
     # Install the Go Linters
     go get -u gopkg.in/alecthomas/gometalinter.v2 && \


### PR DESCRIPTION
Missed the development libraries needed for building, but not for running.
