### PR TITLE
Minimize a subset of the containers

### DIFF
--- a/cgit/Dockerfile
+++ b/cgit/Dockerfile
@@ -1,9 +1,25 @@
-FROM clearlinux/httpd
+FROM clearlinux:latest AS builder
 
-ARG swupd_args
+# Move to latest Clear Linux release to ensure
+# that the swupd command line arguments are
+# correct
 RUN swupd update --no-boot-update $swupd_args
-RUN swupd bundle-add sudo curl scm-server $swupd_args \
-	&& rm -rf /var/lib/swupd/*
 
+# Grab os-release info from the minimal base image so
+# that the new content matches the exact OS version
+COPY --from=clearlinux/os-core:latest /usr/lib/os-release /
+
+# Install additional content in a target directory
+# using the os version from the minimal base
+RUN source /os-release && \
+    mkdir /install_root \
+    && swupd os-install -V ${VERSION_ID} \
+    --path /install_root --statedir /swupd-state \
+    --bundles=sudo,curl,scm-server --no-scripts \
+    && rm -rf /install_root/var/lib/swupd/*
+
+FROM clearlinux/httpd:latest
+
+COPY --from=builder /install_root /
 COPY cgitrc /etc/cgitrc
 COPY httpd-cgit.conf /etc/httpd/conf.d/httpd-cgit.conf

--- a/httpd/Dockerfile
+++ b/httpd/Dockerfile
@@ -1,11 +1,27 @@
-FROM clearlinux:latest
+FROM clearlinux:latest AS builder
+
+# Move to latest Clear Linux release to ensure
+# that the swupd command line arguments are
+# correct
+RUN swupd update --no-boot-update $swupd_args
+
+# Grab os-release info from the minimal base image so
+# that the new content matches the exact OS version
+COPY --from=clearlinux/os-core:latest /usr/lib/os-release /
+
+# Install additional content in a target directory
+# using the os version from the minimal base
+RUN source /os-release && \
+    mkdir /install_root \
+    && swupd os-install -V ${VERSION_ID} \
+    --path /install_root --statedir /swupd-state \
+    --bundles=httpd --no-scripts \
+    && rm -rf /install_root/var/lib/swupd/*
+
+FROM clearlinux/os-core:latest
 MAINTAINER qi.zheng@intel.com
 
-ARG swupd_args
-
-RUN swupd update --no-boot-update $swupd_args
-RUN swupd bundle-add httpd $swupd_args \
-	&& rm -rf /var/lib/swupd/*
+COPY --from=builder /install_root /
 
 #default configuration on /usr/share/defaults/httpd/httpd.conf
 #create folder for default DocumentRoot and LOG/PidFile path

--- a/memcached/Dockerfile
+++ b/memcached/Dockerfile
@@ -1,11 +1,27 @@
-FROM clearlinux:latest
+FROM clearlinux:latest AS builder
+
+# Move to latest Clear Linux release to ensure
+# that the swupd command line arguments are
+# correct
+RUN swupd update --no-boot-update $swupd_args
+
+# Grab os-release info from the minimal base image so
+# that the new content matches the exact OS version
+COPY --from=clearlinux/os-core:latest /usr/lib/os-release /
+
+# Install additional content in a target directory
+# using the os version from the minimal base
+RUN source /os-release && \
+    mkdir /install_root \
+    && swupd os-install -V ${VERSION_ID} \
+    --path /install_root --statedir /swupd-state \
+    --bundles=memcached --no-scripts \
+    && rm -rf /install_root/var/lib/swupd/*
+
+FROM clearlinux/os-core:latest
 MAINTAINER qi.zheng@intel.com
 
-ARG swupd_args
-
-RUN swupd update --no-boot-update $swupd_args
-RUN swupd bundle-add memcached $swupd_args \
-	&& rm -rf /var/lib/swupd/*
+COPY --from=builder /install_root /
 
 COPY docker-entrypoint.sh /usr/local/bin/
 RUN chmod +x /usr/local/bin/docker-entrypoint.sh

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,15 +1,30 @@
-FROM clearlinux:latest
-MAINTAINER bin.yang@intel.com
+FROM clearlinux:latest AS builder
 
-ARG swupd_args
-
+# Move to latest Clear Linux release to ensure
+# that the swupd command line arguments are
+# correct
 RUN swupd update --no-boot-update $swupd_args
 
+# Grab os-release info from the minimal base image so
+# that the new content matches the exact OS version
+COPY --from=clearlinux/os-core:latest /usr/lib/os-release /
+
+# Install additional content in a target directory
+# using the os version from the minimal base
+RUN source /os-release && \
+    mkdir /install_root \
+    && swupd os-install -V ${VERSION_ID} \
+    --path /install_root --statedir /swupd-state \
+    --bundles=nginx --no-scripts \
+    && rm -rf /install_root/var/lib/swupd/*
+
+FROM clearlinux/os-core:latest
+MAINTAINER bin.yang@intel.com
+
+COPY --from=builder /install_root /
 COPY default.conf /etc/nginx/conf.d/default.conf
 
-RUN swupd bundle-add nginx $swupd_args && \
-    rm -rf /var/lib/swupd/* && \
-    mkdir -p /var/log/nginx && \
+RUN mkdir -p /var/log/nginx && \
     # forward request and error logs to docker log collector
     ln -sf /dev/stdout /var/log/nginx/access.log && \
     ln -sf /dev/stderr /var/log/nginx/error.log && \

--- a/os-core/Dockerfile
+++ b/os-core/Dockerfile
@@ -1,0 +1,19 @@
+FROM clearlinux:latest AS builder
+
+ARG swupd_args
+
+# Move to latest Clear Linux release
+RUN swupd update --no-boot-update $swupd_args
+
+# Install clean os-core bundle in target directory
+# using the new os version
+RUN source /usr/lib/os-release \
+    && mkdir /install_root \
+    && swupd os-install -V ${VERSION_ID} \
+    --path /install_root --statedir /swupd-state \
+    --bundles=os-core --no-scripts \
+    && rm -rf /install_root/var/lib/swupd/*
+
+FROM scratch
+COPY --from=builder /install_root /
+CMD ["/bin/bash"]

--- a/os-core/README.md
+++ b/os-core/README.md
@@ -1,0 +1,23 @@
+os-core
+==========
+This provides the common base layer shared by all Clear Linux* based containers.  It
+is not designed to be used stand alone, but to be pulled in via a FROM entry in a new
+Dockerfile.
+
+Build
+-----
+```
+docker build -t clearlinux/os-core .
+```
+
+Or just pull it from Dockerhub
+---------------------------
+```
+docker pull clearlinux/os-core
+```
+
+Extra Build ARGs
+----------------
+- ``swupd_args`` Specifies [SWUPD](https://github.com/clearlinux/swupd-client/blob/master/docs/swupd.1.rst#options) flags
+
+Default build args in Docker are on: https://docs.docker.com/engine/reference/builder/#arg

--- a/redis/Dockerfile
+++ b/redis/Dockerfile
@@ -1,12 +1,29 @@
-FROM clearlinux:latest
+FROM clearlinux:latest AS builder
+
+# Move to latest Clear Linux release to ensure
+# that the swupd command line arguments are
+# correct
+RUN swupd update --no-boot-update $swupd_args
+
+# Grab os-release info from the minimal base image so
+# that the new content matches the exact OS version
+COPY --from=clearlinux/os-core:latest /usr/lib/os-release /
+
+# Install additional content in a target directory
+# using the os version from the minimal base
+RUN source /os-release && \
+    mkdir /install_root \
+    && swupd os-install -V ${VERSION_ID} \
+    --path /install_root --statedir /swupd-state \
+    --bundles=redis-native,findutils --no-scripts \
+    && rm -rf /install_root/var/lib/swupd/*
+
+FROM clearlinux/os-core:latest
 MAINTAINER qi.zheng@intel.com
 
-ARG swupd_args
+COPY --from=builder /install_root /
 
-RUN swupd update --no-boot-update $swupd_args
-RUN swupd bundle-add redis-native $swupd_args \
-	&& rm -rf /var/lib/swupd/* \
-	&& mkdir /data && chown redis:redis /data
+RUN mkdir /data && chown redis:redis /data
 
 VOLUME /data
 WORKDIR /data


### PR DESCRIPTION
This pull request uses the docker multistage build technique to create a new container called clearlinux/os-core that only contains os-core, and then converts redis, httpd, cgi, nginx, and memcached to use os-core as the base layer while also using a multistage build to pull in additional content (since the base layer does not have os-core-update installed.)