### PR TITLE
Minimize postgres container size using the os-core container

### DIFF
--- a/postgres/Dockerfile
+++ b/postgres/Dockerfile
@@ -1,11 +1,27 @@
-FROM clearlinux:latest
+FROM clearlinux:latest AS builder
 MAINTAINER william.douglas@intel.com
 
 ARG swupd_args
-
+# Move to latest Clear Linux release to ensure
+# that the swupd command line arguments are
+# correct
 RUN swupd update --no-boot-update $swupd_args
-RUN swupd bundle-add postgresql $swupd_args \
-	&& rm -rf /var/lib/swupd/*
+
+# Grab os-release info from the minimal base image so
+# that the new content matches the exact OS version
+COPY --from=clearlinux/os-core:latest /usr/lib/os-release /
+
+# Install additional content in a target directory
+# using the os version from the minimal base
+RUN source /os-release && \
+    mkdir /install_root \
+    && swupd os-install -V ${VERSION_ID} \
+    --path /install_root --statedir /swupd-state \
+    --bundles=postgresql --no-scripts
+
+FROM clearlinux/os-core:latest
+
+COPY --from=builder /install_root /
 
 ENV PGDATA /var/lib/pgsql/data
 RUN mkdir -p /run/postgresql && chown -R postgres:postgres /run/postgresql


### PR DESCRIPTION
Convert postgres container to be based on the minimal os-core
container, using a multistage build technique to add additional
Clear Linux content.

Signed-off-by: Liu, Jianjun <jianjun.liu@intel.com>