### PR TITLE
Minimize mariadb container using the os-core container.

### DIFF
--- a/mariadb/Dockerfile
+++ b/mariadb/Dockerfile
@@ -1,11 +1,29 @@
-FROM clearlinux:latest
-MAINTAINER qi.zheng@intel.com
+FROM clearlinux:latest as builder
 
 ARG swupd_args
 
+# Move to latest Clear Linux release to ensure
+# that the swupd command line arguments are
+# correct
 RUN swupd update --no-boot-update $swupd_args
-RUN swupd bundle-add mariadb $swupd_args \
-	&& rm -rf /var/lib/swupd/*
+
+# Grab os-release info from the minimal base image so
+# that the new content matches the exact OS version
+COPY --from=clearlinux/os-core:latest /usr/lib/os-release /
+
+# Install additional content in a target directory
+# using the os version from the minimal base
+RUN source /os-release && \
+    mkdir /install_root \
+    && swupd os-install -V ${VERSION_ID} \
+    --path /install_root --statedir /swupd-state \
+    --bundles=mariadb --no-scripts \
+    && rm -rf /install_root/var/lib/swupd/*
+
+FROM clearlinux/os-core:latest
+MAINTAINER qi.zheng@intel.com
+
+COPY --from=builder /install_root /
 
 RUN mkdir /docker-entrypoint-initdb.d
 RUN set -ex; \


### PR DESCRIPTION
Convert mariadb container to be based on the minimal os-core
container, using a multistage build technique to add additional
Clear Linux content.

Signed-off-by: Rusty Lynch<rusty.lynch@intel.com>