### PR TITLE
only copy delta files during multistage build

### DIFF
--- a/cgit/Dockerfile
+++ b/cgit/Dockerfile
@@ -18,6 +18,15 @@ RUN source /os-release && \
     --bundles=sudo,curl,scm-server --no-scripts \
     && rm -rf /install_root/var/lib/swupd/*
 
+# For some Host OS configuration with redirect_dir on,
+# extra data are saved on the upper layer when the same
+# file exists on different layers. To minimize docker
+# image size, remove the overlapped files before copy.
+RUN mkdir /os_core_install
+COPY --from=clearlinux/os-core:latest / /os_core_install/
+RUN cd / && \
+    find os_core_install | sed -e 's/os_core_install/install_root/' | xargs rm -d || true
+
 FROM clearlinux/httpd:latest
 
 COPY --from=builder /install_root /

--- a/elasticsearch/Dockerfile
+++ b/elasticsearch/Dockerfile
@@ -1,11 +1,36 @@
-FROM clearlinux:latest
+FROM clearlinux:latest AS builder
 MAINTAINER qi.zheng@intel.com
 
 ARG swupd_args
-
+# Move to latest Clear Linux release to ensure
+# that the swupd command line arguments are
+# correct
 RUN swupd update --no-boot-update $swupd_args
-RUN swupd bundle-add elasticsearch $swupd_args \
-	&& rm -rf /var/lib/swupd/*
+
+# Grab os-release info from the minimal base image so
+# that the new content matches the exact OS version
+COPY --from=clearlinux/os-core:latest /usr/lib/os-release /
+
+# Install additional content in a target directory
+# using the os version from the minimal base
+RUN source /os-release && \
+    mkdir /install_root \
+    && swupd os-install -V ${VERSION_ID} \
+    --path /install_root --statedir /swupd-state \
+    --bundles=elasticsearch --no-scripts
+
+# For some Host OS configuration with redirect_dir on,
+# extra data are saved on the upper layer when the same
+# file exists on different layers. To minimize docker
+# image size, remove the overlapped files before copy.
+RUN mkdir /os_core_install
+COPY --from=clearlinux/os-core:latest / /os_core_install/
+RUN cd / && \
+    find os_core_install | sed -e 's/os_core_install/install_root/' | xargs rm -d || true
+
+FROM clearlinux/os-core:latest
+
+COPY --from=builder /install_root /
 
 RUN set -ex \
 	&& for path in \

--- a/flink/Dockerfile
+++ b/flink/Dockerfile
@@ -1,10 +1,37 @@
-FROM clearlinux:latest
+FROM clearlinux:latest AS builder
 MAINTAINER hongzhan.chen@intel.com
 
-#Install apache-flink bundle
+ARG swupd_args
+# Move to latest Clear Linux release to ensure
+# that the swupd command line arguments are
+# correct
 RUN swupd update --no-boot-update $swupd_args
-RUN swupd bundle-add apache-flink $swupd_arg \
-        && rm -rf /var/lib/swupd/*
+
+# Grab os-release info from the minimal base image so
+# that the new content matches the exact OS version
+COPY --from=clearlinux/os-core:latest /usr/lib/os-release /
+
+# Install additional content in a target directory
+# using the os version from the minimal base
+RUN source /os-release && \
+    mkdir /install_root \
+    && swupd os-install -V ${VERSION_ID} \
+    --path /install_root --statedir /swupd-state \
+    --bundles=apache-flink --no-scripts
+
+# For some Host OS configuration with redirect_dir on,
+# extra data are saved on the upper layer when the same
+# file exists on different layers. To minimize docker
+# image size, remove the overlapped files before copy.
+RUN mkdir /os_core_install
+COPY --from=clearlinux/os-core:latest / /os_core_install/
+RUN cd / && \
+    find os_core_install | sed -e 's/os_core_install/install_root/' | xargs rm -d || true
+
+
+FROM clearlinux/os-core:latest
+
+COPY --from=builder /install_root /
 
 # Configure Flink version
 ENV FLINK_VERSION=1.7.2

--- a/haproxy/Dockerfile
+++ b/haproxy/Dockerfile
@@ -1,13 +1,39 @@
-FROM clearlinux:latest
+FROM clearlinux:latest  AS builder
 MAINTAINER sophia.gong@intel.com
 
 ARG swupd_args
-
+# Move to latest Clear Linux release to ensure
+# that the swupd command line arguments are
+# correct
 RUN swupd update --no-boot-update $swupd_args
 
-RUN swupd bundle-add haproxy $swupd_args \
-    && rm -rf /var/lib/swupd/* \
-    && mkdir -p /usr/local/etc/haproxy
+# Grab os-release info from the minimal base image so
+# that the new content matches the exact OS version
+COPY --from=clearlinux/os-core:latest /usr/lib/os-release /
+
+# Install additional content in a target directory
+# using the os version from the minimal base
+RUN source /os-release && \
+    mkdir /install_root \
+    && swupd os-install -V ${VERSION_ID} \
+    --path /install_root --statedir /swupd-state \
+    --bundles=haproxy --no-scripts
+
+# For some Host OS configuration with redirect_dir on,
+# extra data are saved on the upper layer when the same
+# file exists on different layers. To minimize docker
+# image size, remove the overlapped files before copy.
+RUN mkdir /os_core_install
+COPY --from=clearlinux/os-core:latest / /os_core_install/
+RUN cd / && \
+    find os_core_install | sed -e 's/os_core_install/install_root/' | xargs rm -d || true
+
+
+FROM clearlinux/os-core:latest
+
+COPY --from=builder /install_root /
+
+RUN mkdir -p /usr/local/etc/haproxy
 
 STOPSIGNAL SIGUSR1
 

--- a/httpd/Dockerfile
+++ b/httpd/Dockerfile
@@ -18,6 +18,15 @@ RUN source /os-release && \
     --bundles=httpd --no-scripts \
     && rm -rf /install_root/var/lib/swupd/*
 
+# For some Host OS configuration with redirect_dir on,
+# extra data are saved on the upper layer when the same
+# file exists on different layers. To minimize docker
+# image size, remove the overlapped files before copy.
+RUN mkdir /os_core_install
+COPY --from=clearlinux/os-core:latest / /os_core_install/
+RUN cd / && \
+    find os_core_install | sed -e 's/os_core_install/install_root/' | xargs rm -d || true
+
 FROM clearlinux/os-core:latest
 MAINTAINER qi.zheng@intel.com
 

--- a/iperf/Dockerfile
+++ b/iperf/Dockerfile
@@ -1,11 +1,37 @@
-FROM clearlinux:latest
+FROM clearlinux:latest  AS builder
 MAINTAINER long1.wang@intel.com
 
 ARG swupd_args
-
+# Move to latest Clear Linux release to ensure
+# that the swupd command line arguments are
+# correct
 RUN swupd update --no-boot-update $swupd_args
-RUN swupd bundle-add iperf $swupd_args \
-	&& rm -rf /var/lib/swupd/*
+
+# Grab os-release info from the minimal base image so
+# that the new content matches the exact OS version
+COPY --from=clearlinux/os-core:latest /usr/lib/os-release /
+
+# Install additional content in a target directory
+# using the os version from the minimal base
+RUN source /os-release && \
+    mkdir /install_root \
+    && swupd os-install -V ${VERSION_ID} \
+    --path /install_root --statedir /swupd-state \
+    --bundles=iperf --no-scripts
+
+# For some Host OS configuration with redirect_dir on,
+# extra data are saved on the upper layer when the same
+# file exists on different layers. To minimize docker
+# image size, remove the overlapped files before copy.
+RUN mkdir /os_core_install
+COPY --from=clearlinux/os-core:latest / /os_core_install/
+RUN cd / && \
+    find os_core_install | sed -e 's/os_core_install/install_root/' | xargs rm -d || true
+
+
+FROM clearlinux/os-core:latest
+
+COPY --from=builder /install_root /
 
 # Define default command
 ENTRYPOINT ["iperf3"]

--- a/mariadb/Dockerfile
+++ b/mariadb/Dockerfile
@@ -20,6 +20,15 @@ RUN source /os-release && \
     --bundles=mariadb --no-scripts \
     && rm -rf /install_root/var/lib/swupd/*
 
+# For some Host OS configuration with redirect_dir on,
+# extra data are saved on the upper layer when the same
+# file exists on different layers. To minimize docker
+# image size, remove the overlapped files before copy.
+RUN mkdir /os_core_install
+COPY --from=clearlinux/os-core:latest / /os_core_install/
+RUN cd / && \
+    find os_core_install | sed -e 's/os_core_install/install_root/' | xargs rm -d || true
+
 FROM clearlinux/os-core:latest
 MAINTAINER qi.zheng@intel.com
 

--- a/memcached/Dockerfile
+++ b/memcached/Dockerfile
@@ -18,6 +18,15 @@ RUN source /os-release && \
     --bundles=memcached --no-scripts \
     && rm -rf /install_root/var/lib/swupd/*
 
+# For some Host OS configuration with redirect_dir on,
+# extra data are saved on the upper layer when the same
+# file exists on different layers. To minimize docker
+# image size, remove the overlapped files before copy.
+RUN mkdir /os_core_install
+COPY --from=clearlinux/os-core:latest / /os_core_install/
+RUN cd / && \
+    find os_core_install | sed -e 's/os_core_install/install_root/' | xargs rm -d || true
+
 FROM clearlinux/os-core:latest
 MAINTAINER qi.zheng@intel.com
 

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -18,6 +18,15 @@ RUN source /os-release && \
     --bundles=nginx --no-scripts \
     && rm -rf /install_root/var/lib/swupd/*
 
+# For some Host OS configuration with redirect_dir on,
+# extra data are saved on the upper layer when the same
+# file exists on different layers. To minimize docker
+# image size, remove the overlapped files before copy.
+RUN mkdir /os_core_install
+COPY --from=clearlinux/os-core:latest / /os_core_install/
+RUN cd / && \
+    find os_core_install | sed -e 's/os_core_install/install_root/' | xargs rm -d || true
+
 FROM clearlinux/os-core:latest
 MAINTAINER bin.yang@intel.com
 

--- a/postgres/Dockerfile
+++ b/postgres/Dockerfile
@@ -19,6 +19,15 @@ RUN source /os-release && \
     --path /install_root --statedir /swupd-state \
     --bundles=postgresql --no-scripts
 
+# For some Host OS configuration with redirect_dir on,
+# extra data are saved on the upper layer when the same
+# file exists on different layers. To minimize docker
+# image size, remove the overlapped files before copy.
+RUN mkdir /os_core_install
+COPY --from=clearlinux/os-core:latest / /os_core_install/
+RUN cd / && \
+    find os_core_install | sed -e 's/os_core_install/install_root/' | xargs rm -d || true
+
 FROM clearlinux/os-core:latest
 
 COPY --from=builder /install_root /


### PR DESCRIPTION
For some Host OS configuration with redirect_dir on,
extra data are saved on the upper layer when the same
file exists on different layers. To minimize docker
image size, remove the overlapped files before copy.

Signed-off-by: Liu, Jianjun <jianjun.liu@intel.com>