### PR TITLE
Minimize containers size using the os-core container

### DIFF
--- a/golang/Dockerfile
+++ b/golang/Dockerfile
@@ -1,11 +1,36 @@
-FROM clearlinux:latest
+FROM clearlinux:latest AS builder
 MAINTAINER qi.zheng@intel.com
 
 ARG swupd_args
-
+# Move to latest Clear Linux release to ensure
+# that the swupd command line arguments are
+# correct
 RUN swupd update --no-boot-update $swupd_args
-RUN swupd bundle-add go-basic $swupd_args \
-	&& rm -rf /var/lib/swupd/*
+
+# Grab os-release info from the minimal base image so
+# that the new content matches the exact OS version
+COPY --from=clearlinux/os-core:latest /usr/lib/os-release /
+
+# Install additional content in a target directory
+# using the os version from the minimal base
+RUN source /os-release && \
+    mkdir /install_root \
+    && swupd os-install -V ${VERSION_ID} \
+    --path /install_root --statedir /swupd-state \
+    --bundles=os-core-update,go-basic --no-scripts
+
+# For some Host OS configuration with redirect_dir on,
+# extra data are saved on the upper layer when the same
+# file exists on different layers. To minimize docker
+# image size, remove the overlapped files before copy.
+RUN mkdir /os_core_install
+COPY --from=clearlinux/os-core:latest / /os_core_install/
+RUN cd / && \
+    find os_core_install | sed -e 's/os_core_install/install_root/' | xargs rm -d || true
+
+FROM clearlinux/os-core:latest
+
+COPY --from=builder /install_root /
 
 ENV GOPATH /go
 ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH

--- a/node/Dockerfile
+++ b/node/Dockerfile
@@ -1,10 +1,36 @@
-FROM clearlinux:latest
+FROM clearlinux:latest AS builder
 MAINTAINER jianjun.liu@intel.com
 
 ARG swupd_args
-
+# Move to latest Clear Linux release to ensure
+# that the swupd command line arguments are
+# correct
 RUN swupd update --no-boot-update $swupd_args
-RUN swupd bundle-add nodejs-basic $swupd_args \
-	&& rm -rf /var/lib/swupd/*
+
+# Grab os-release info from the minimal base image so
+# that the new content matches the exact OS version
+COPY --from=clearlinux/os-core:latest /usr/lib/os-release /
+
+# Install additional content in a target directory
+# using the os version from the minimal base
+RUN source /os-release && \
+    mkdir /install_root \
+    && swupd os-install -V ${VERSION_ID} \
+    --path /install_root --statedir /swupd-state \
+    --bundles=os-core-update,nodejs-basic --no-scripts
+
+# For some Host OS configuration with redirect_dir on,
+# extra data are saved on the upper layer when the same
+# file exists on different layers. To minimize docker
+# image size, remove the overlapped files before copy.
+RUN mkdir /os_core_install
+COPY --from=clearlinux/os-core:latest / /os_core_install/
+RUN cd / && \
+    find os_core_install | sed -e 's/os_core_install/install_root/' | xargs rm -d || true
+
+
+FROM clearlinux/os-core:latest
+
+COPY --from=builder /install_root /
 
 CMD ["node"]

--- a/openjdk/Dockerfile
+++ b/openjdk/Dockerfile
@@ -1,10 +1,36 @@
-FROM clearlinux:latest
+FROM clearlinux:latest AS builder
 MAINTAINER long1.wang@intel.com
 
 ARG swupd_args
-
+# Move to latest Clear Linux release to ensure
+# that the swupd command line arguments are
+# correct
 RUN swupd update --no-boot-update $swupd_args
-RUN swupd bundle-add java-runtime $swupd_args && \
-    rm -rf /var/lib/swupd/*
+
+# Grab os-release info from the minimal base image so
+# that the new content matches the exact OS version
+COPY --from=clearlinux/os-core:latest /usr/lib/os-release /
+
+# Install additional content in a target directory
+# using the os version from the minimal base
+RUN source /os-release && \
+    mkdir /install_root \
+    && swupd os-install -V ${VERSION_ID} \
+    --path /install_root --statedir /swupd-state \
+    --bundles=os-core-update,java-runtime --no-scripts
+
+# For some Host OS configuration with redirect_dir on,
+# extra data are saved on the upper layer when the same
+# file exists on different layers. To minimize docker
+# image size, remove the overlapped files before copy.
+RUN mkdir /os_core_install
+COPY --from=clearlinux/os-core:latest / /os_core_install/
+RUN cd / && \
+    find os_core_install | sed -e 's/os_core_install/install_root/' | xargs rm -d || true
+
+
+FROM clearlinux/os-core:latest
+
+COPY --from=builder /install_root /
 
 CMD ["java"]

--- a/perl/Dockerfile
+++ b/perl/Dockerfile
@@ -1,11 +1,36 @@
-FROM clearlinux:latest
+FROM clearlinux:latest AS builder
 MAINTAINER qi.zheng@intel.com
 
 ARG swupd_args
-
+# Move to latest Clear Linux release to ensure
+# that the swupd command line arguments are
+# correct
 RUN swupd update --no-boot-update $swupd_args
-RUN swupd bundle-add perl-extras $swupd_args \
-	&& rm -rf /var/lib/swupd/*
+
+# Grab os-release info from the minimal base image so
+# that the new content matches the exact OS version
+COPY --from=clearlinux/os-core:latest /usr/lib/os-release /
+
+# Install additional content in a target directory
+# using the os version from the minimal base
+RUN source /os-release && \
+    mkdir /install_root \
+    && swupd os-install -V ${VERSION_ID} \
+    --path /install_root --statedir /swupd-state \
+    --bundles=os-core-update,perl-extras --no-scripts
+
+# For some Host OS configuration with redirect_dir on,
+# extra data are saved on the upper layer when the same
+# file exists on different layers. To minimize docker
+# image size, remove the overlapped files before copy.
+RUN mkdir /os_core_install
+COPY --from=clearlinux/os-core:latest / /os_core_install/
+RUN cd / && \
+    find os_core_install | sed -e 's/os_core_install/install_root/' | xargs rm -d || true
+
+FROM clearlinux/os-core:latest
+
+COPY --from=builder /install_root /
 
 WORKDIR /root
 

--- a/php/Dockerfile
+++ b/php/Dockerfile
@@ -1,10 +1,36 @@
-FROM clearlinux:latest
+FROM clearlinux:latest AS builder
 MAINTAINER jianjun.liu@intel.com
 
 ARG swupd_args
-
+# Move to latest Clear Linux release to ensure
+# that the swupd command line arguments are
+# correct
 RUN swupd update --no-boot-update $swupd_args
-RUN swupd bundle-add php-basic $swupd_args \
-	&& rm -rf /var/lib/swupd/*
+
+# Grab os-release info from the minimal base image so
+# that the new content matches the exact OS version
+COPY --from=clearlinux/os-core:latest /usr/lib/os-release /
+
+# Install additional content in a target directory
+# using the os version from the minimal base
+RUN source /os-release && \
+    mkdir /install_root \
+    && swupd os-install -V ${VERSION_ID} \
+    --path /install_root --statedir /swupd-state \
+    --bundles=os-core-update,php-basic --no-scripts
+
+# For some Host OS configuration with redirect_dir on,
+# extra data are saved on the upper layer when the same
+# file exists on different layers. To minimize docker
+# image size, remove the overlapped files before copy.
+RUN mkdir /os_core_install
+COPY --from=clearlinux/os-core:latest / /os_core_install/
+RUN cd / && \
+    find os_core_install | sed -e 's/os_core_install/install_root/' | xargs rm -d || true
+
+
+FROM clearlinux/os-core:latest
+
+COPY --from=builder /install_root /
 
 CMD ["php","-a"]

--- a/python/Dockerfile
+++ b/python/Dockerfile
@@ -1,10 +1,36 @@
-FROM clearlinux:latest
+FROM clearlinux:latest AS builder
 MAINTAINER hongzhan.chen@intel.com
 
 ARG swupd_args
-
+# Move to latest Clear Linux release to ensure
+# that the swupd command line arguments are
+# correct
 RUN swupd update --no-boot-update $swupd_args
-RUN swupd bundle-add python3-basic $swupd_args \
-	&& rm -rf /var/lib/swupd/*
+
+# Grab os-release info from the minimal base image so
+# that the new content matches the exact OS version
+COPY --from=clearlinux/os-core:latest /usr/lib/os-release /
+
+# Install additional content in a target directory
+# using the os version from the minimal base
+RUN source /os-release && \
+    mkdir /install_root \
+    && swupd os-install -V ${VERSION_ID} \
+    --path /install_root --statedir /swupd-state \
+    --bundles=os-core-update,python3-basic --no-scripts
+
+# For some Host OS configuration with redirect_dir on,
+# extra data are saved on the upper layer when the same
+# file exists on different layers. To minimize docker
+# image size, remove the overlapped files before copy.
+RUN mkdir /os_core_install
+COPY --from=clearlinux/os-core:latest / /os_core_install/
+RUN cd / && \
+    find os_core_install | sed -e 's/os_core_install/install_root/' | xargs rm -d || true
+
+
+FROM clearlinux/os-core:latest
+
+COPY --from=builder /install_root /
 
 CMD ["python3"]

--- a/rabbitmq/Dockerfile
+++ b/rabbitmq/Dockerfile
@@ -1,11 +1,36 @@
-FROM clearlinux:latest
+FROM clearlinux:latest AS builder
 MAINTAINER long1.wang@intel.com
 
 ARG swupd_args
+# Move to latest Clear Linux release to ensure
+# that the swupd command line arguments are
+# correct
+RUN swupd update --no-boot-update $swupd_args
 
-RUN swupd update --no-boot-update $swupd_args && \
-    swupd bundle-add openstack-common $swupd_args && \
-    rm -rf /var/lib/swupd
+# Grab os-release info from the minimal base image so
+# that the new content matches the exact OS version
+COPY --from=clearlinux/os-core:latest /usr/lib/os-release /
+
+# Install additional content in a target directory
+# using the os version from the minimal base
+RUN source /os-release && \
+    mkdir /install_root \
+    && swupd os-install -V ${VERSION_ID} \
+    --path /install_root --statedir /swupd-state \
+    --bundles=os-core-update,openstack-common --no-scripts
+
+# For some Host OS configuration with redirect_dir on,
+# extra data are saved on the upper layer when the same
+# file exists on different layers. To minimize docker
+# image size, remove the overlapped files before copy.
+RUN mkdir /os_core_install
+COPY --from=clearlinux/os-core:latest / /os_core_install/
+RUN cd / && \
+    find os_core_install | sed -e 's/os_core_install/install_root/' | xargs rm -d || true
+
+FROM clearlinux/os-core:latest
+
+COPY --from=builder /install_root /
 
 EXPOSE 4369 5671 5672 25672
 CMD ["rabbitmq-server"]

--- a/ruby/Dockerfile
+++ b/ruby/Dockerfile
@@ -1,8 +1,35 @@
-FROM clearlinux:latest
+FROM clearlinux:latest AS builder
 MAINTAINER hongzhan.chen@intel.com
 
+ARG swupd_args
+# Move to latest Clear Linux release to ensure
+# that the swupd command line arguments are
+# correct
 RUN swupd update --no-boot-update $swupd_args
-RUN swupd bundle-add ruby-basic $swupd_args \
-	&& rm -rf /var/lib/swupd/*
+
+# Grab os-release info from the minimal base image so
+# that the new content matches the exact OS version
+COPY --from=clearlinux/os-core:latest /usr/lib/os-release /
+
+# Install additional content in a target directory
+# using the os version from the minimal base
+RUN source /os-release && \
+    mkdir /install_root \
+    && swupd os-install -V ${VERSION_ID} \
+    --path /install_root --statedir /swupd-state \
+    --bundles=os-core-update,ruby-basic --no-scripts
+
+# For some Host OS configuration with redirect_dir on,
+# extra data are saved on the upper layer when the same
+# file exists on different layers. To minimize docker
+# image size, remove the overlapped files before copy.
+RUN mkdir /os_core_install
+COPY --from=clearlinux/os-core:latest / /os_core_install/
+RUN cd / && \
+    find os_core_install | sed -e 's/os_core_install/install_root/' | xargs rm -d || true
+
+FROM clearlinux/os-core:latest
+
+COPY --from=builder /install_root /
 
 CMD ["irb"]

--- a/tensorflow/Dockerfile
+++ b/tensorflow/Dockerfile
@@ -1,8 +1,34 @@
-FROM clearlinux:latest
+FROM clearlinux:latest AS builder
 MAINTAINER jianjun.liu@intel.com
 
 ARG swupd_args
-
+# Move to latest Clear Linux release to ensure
+# that the swupd command line arguments are
+# correct
 RUN swupd update --no-boot-update $swupd_args
-RUN swupd bundle-add machine-learning-tensorflow $swupd_args \
-	&& rm -rf /var/lib/swupd/*
+
+# Grab os-release info from the minimal base image so
+# that the new content matches the exact OS version
+COPY --from=clearlinux/os-core:latest /usr/lib/os-release /
+
+# Install additional content in a target directory
+# using the os version from the minimal base
+RUN source /os-release && \
+    mkdir /install_root \
+    && swupd os-install -V ${VERSION_ID} \
+    --path /install_root --statedir /swupd-state \
+    --bundles=os-core-update,machine-learning-tensorflow --no-scripts
+
+# For some Host OS configuration with redirect_dir on,
+# extra data are saved on the upper layer when the same
+# file exists on different layers. To minimize docker
+# image size, remove the overlapped files before copy.
+RUN mkdir /os_core_install
+COPY --from=clearlinux/os-core:latest / /os_core_install/
+RUN cd / && \
+    find os_core_install | sed -e 's/os_core_install/install_root/' | xargs rm -d || true
+
+
+FROM clearlinux/os-core:latest
+
+COPY --from=builder /install_root /


### PR DESCRIPTION
Convert golang, node, openjdk, perl, php, python,
rabbitmq, ruby and tensorflow containers to be based
on the minimal os-core container, using a multistage
build technique to add additional Clear Linux content.

Signed-off-by: Liu, Jianjun <jianjun.liu@intel.com>