### PR TITLE
enable swupd function for flink container

### DIFF
--- a/flink/Dockerfile
+++ b/flink/Dockerfile
@@ -17,7 +17,7 @@ RUN source /os-release && \
     mkdir /install_root \
     && swupd os-install -V ${VERSION_ID} \
     --path /install_root --statedir /swupd-state \
-    --bundles=apache-flink --no-scripts
+    --bundles=os-core-update,apache-flink --no-scripts
 
 # For some Host OS configuration with redirect_dir on,
 # extra data are saved on the upper layer when the same


### PR DESCRIPTION
Enable swupd for flink as it needs to install
java and other bundles most of the time.

Signed-off-by: Liu, Jianjun <jianjun.liu@intel.com>