### PR TITLE
Hide the expected warning msg

### DIFF
--- a/cassandra/Dockerfile
+++ b/cassandra/Dockerfile
@@ -25,7 +25,7 @@ RUN source /os-release && \
 RUN mkdir /os_core_install
 COPY --from=clearlinux/os-core:latest / /os_core_install/
 RUN cd / && \
-    find os_core_install | sed -e 's/os_core_install/install_root/' | xargs rm -d || true
+    find os_core_install | sed -e 's/os_core_install/install_root/' | xargs rm -d &> /dev/null || true
 
 FROM clearlinux/os-core:latest
 MAINTAINER wang.jue@intel.com

--- a/cgit/Dockerfile
+++ b/cgit/Dockerfile
@@ -25,7 +25,7 @@ RUN source /os-release && \
 RUN mkdir /os_core_install
 COPY --from=clearlinux/os-core:latest / /os_core_install/
 RUN cd / && \
-    find os_core_install | sed -e 's/os_core_install/install_root/' | xargs rm -d || true
+    find os_core_install | sed -e 's/os_core_install/install_root/' | xargs rm -d &> /dev/null || true
 
 FROM clearlinux/httpd:latest
 

--- a/elasticsearch/Dockerfile
+++ b/elasticsearch/Dockerfile
@@ -26,7 +26,7 @@ RUN source /os-release && \
 RUN mkdir /os_core_install
 COPY --from=clearlinux/os-core:latest / /os_core_install/
 RUN cd / && \
-    find os_core_install | sed -e 's/os_core_install/install_root/' | xargs rm -d || true
+    find os_core_install | sed -e 's/os_core_install/install_root/' | xargs rm -d &> /dev/null || true
 
 FROM clearlinux/os-core:latest
 

--- a/flink/Dockerfile
+++ b/flink/Dockerfile
@@ -26,7 +26,7 @@ RUN source /os-release && \
 RUN mkdir /os_core_install
 COPY --from=clearlinux/os-core:latest / /os_core_install/
 RUN cd / && \
-    find os_core_install | sed -e 's/os_core_install/install_root/' | xargs rm -d || true
+    find os_core_install | sed -e 's/os_core_install/install_root/' | xargs rm -d &> /dev/null || true
 
 
 FROM clearlinux/os-core:latest

--- a/golang/Dockerfile
+++ b/golang/Dockerfile
@@ -26,7 +26,7 @@ RUN source /os-release && \
 RUN mkdir /os_core_install
 COPY --from=clearlinux/os-core:latest / /os_core_install/
 RUN cd / && \
-    find os_core_install | sed -e 's/os_core_install/install_root/' | xargs rm -d || true
+    find os_core_install | sed -e 's/os_core_install/install_root/' | xargs rm -d &> /dev/null || true
 
 FROM clearlinux/os-core:latest
 

--- a/haproxy/Dockerfile
+++ b/haproxy/Dockerfile
@@ -26,7 +26,7 @@ RUN source /os-release && \
 RUN mkdir /os_core_install
 COPY --from=clearlinux/os-core:latest / /os_core_install/
 RUN cd / && \
-    find os_core_install | sed -e 's/os_core_install/install_root/' | xargs rm -d || true
+    find os_core_install | sed -e 's/os_core_install/install_root/' | xargs rm -d &> /dev/null || true
 
 
 FROM clearlinux/os-core:latest

--- a/httpd/Dockerfile
+++ b/httpd/Dockerfile
@@ -25,7 +25,7 @@ RUN source /os-release && \
 RUN mkdir /os_core_install
 COPY --from=clearlinux/os-core:latest / /os_core_install/
 RUN cd / && \
-    find os_core_install | sed -e 's/os_core_install/install_root/' | xargs rm -d || true
+    find os_core_install | sed -e 's/os_core_install/install_root/' | xargs rm -d &> /dev/null || true
 
 FROM clearlinux/os-core:latest
 MAINTAINER qi.zheng@intel.com

--- a/iperf/Dockerfile
+++ b/iperf/Dockerfile
@@ -26,7 +26,7 @@ RUN source /os-release && \
 RUN mkdir /os_core_install
 COPY --from=clearlinux/os-core:latest / /os_core_install/
 RUN cd / && \
-    find os_core_install | sed -e 's/os_core_install/install_root/' | xargs rm -d || true
+    find os_core_install | sed -e 's/os_core_install/install_root/' | xargs rm -d &> /dev/null || true
 
 
 FROM clearlinux/os-core:latest

--- a/mariadb/Dockerfile
+++ b/mariadb/Dockerfile
@@ -27,7 +27,7 @@ RUN source /os-release && \
 RUN mkdir /os_core_install
 COPY --from=clearlinux/os-core:latest / /os_core_install/
 RUN cd / && \
-    find os_core_install | sed -e 's/os_core_install/install_root/' | xargs rm -d || true
+    find os_core_install | sed -e 's/os_core_install/install_root/' | xargs rm -d &> /dev/null || true
 
 FROM clearlinux/os-core:latest
 MAINTAINER qi.zheng@intel.com

--- a/memcached/Dockerfile
+++ b/memcached/Dockerfile
@@ -25,7 +25,7 @@ RUN source /os-release && \
 RUN mkdir /os_core_install
 COPY --from=clearlinux/os-core:latest / /os_core_install/
 RUN cd / && \
-    find os_core_install | sed -e 's/os_core_install/install_root/' | xargs rm -d || true
+    find os_core_install | sed -e 's/os_core_install/install_root/' | xargs rm -d &> /dev/null || true
 
 FROM clearlinux/os-core:latest
 MAINTAINER qi.zheng@intel.com

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -25,7 +25,7 @@ RUN source /os-release && \
 RUN mkdir /os_core_install
 COPY --from=clearlinux/os-core:latest / /os_core_install/
 RUN cd / && \
-    find os_core_install | sed -e 's/os_core_install/install_root/' | xargs rm -d || true
+    find os_core_install | sed -e 's/os_core_install/install_root/' | xargs rm -d &> /dev/null || true
 
 FROM clearlinux/os-core:latest
 MAINTAINER bin.yang@intel.com

--- a/node/Dockerfile
+++ b/node/Dockerfile
@@ -26,7 +26,7 @@ RUN source /os-release && \
 RUN mkdir /os_core_install
 COPY --from=clearlinux/os-core:latest / /os_core_install/
 RUN cd / && \
-    find os_core_install | sed -e 's/os_core_install/install_root/' | xargs rm -d || true
+    find os_core_install | sed -e 's/os_core_install/install_root/' | xargs rm -d &> /dev/null || true
 
 
 FROM clearlinux/os-core:latest

--- a/openjdk/Dockerfile
+++ b/openjdk/Dockerfile
@@ -26,7 +26,7 @@ RUN source /os-release && \
 RUN mkdir /os_core_install
 COPY --from=clearlinux/os-core:latest / /os_core_install/
 RUN cd / && \
-    find os_core_install | sed -e 's/os_core_install/install_root/' | xargs rm -d || true
+    find os_core_install | sed -e 's/os_core_install/install_root/' | xargs rm -d &> /dev/null || true
 
 
 FROM clearlinux/os-core:latest

--- a/perl/Dockerfile
+++ b/perl/Dockerfile
@@ -26,7 +26,7 @@ RUN source /os-release && \
 RUN mkdir /os_core_install
 COPY --from=clearlinux/os-core:latest / /os_core_install/
 RUN cd / && \
-    find os_core_install | sed -e 's/os_core_install/install_root/' | xargs rm -d || true
+    find os_core_install | sed -e 's/os_core_install/install_root/' | xargs rm -d &> /dev/null || true
 
 FROM clearlinux/os-core:latest
 

--- a/php-fpm/Dockerfile
+++ b/php-fpm/Dockerfile
@@ -26,7 +26,7 @@ RUN source /os-release && \
 RUN mkdir /os_core_install
 COPY --from=clearlinux/os-core:latest / /os_core_install/
 RUN cd / && \
-    find os_core_install | sed -e 's/os_core_install/install_root/' | xargs rm -d || true
+    find os_core_install | sed -e 's/os_core_install/install_root/' | xargs rm -d &> /dev/null || true
 
 
 FROM clearlinux/os-core:latest

--- a/php/Dockerfile
+++ b/php/Dockerfile
@@ -26,7 +26,7 @@ RUN source /os-release && \
 RUN mkdir /os_core_install
 COPY --from=clearlinux/os-core:latest / /os_core_install/
 RUN cd / && \
-    find os_core_install | sed -e 's/os_core_install/install_root/' | xargs rm -d || true
+    find os_core_install | sed -e 's/os_core_install/install_root/' | xargs rm -d &> /dev/null || true
 
 
 FROM clearlinux/os-core:latest

--- a/postgres/Dockerfile
+++ b/postgres/Dockerfile
@@ -26,7 +26,7 @@ RUN source /os-release && \
 RUN mkdir /os_core_install
 COPY --from=clearlinux/os-core:latest / /os_core_install/
 RUN cd / && \
-    find os_core_install | sed -e 's/os_core_install/install_root/' | xargs rm -d || true
+    find os_core_install | sed -e 's/os_core_install/install_root/' | xargs rm -d &> /dev/null || true
 
 FROM clearlinux/os-core:latest
 

--- a/python/Dockerfile
+++ b/python/Dockerfile
@@ -26,7 +26,7 @@ RUN source /os-release && \
 RUN mkdir /os_core_install
 COPY --from=clearlinux/os-core:latest / /os_core_install/
 RUN cd / && \
-    find os_core_install | sed -e 's/os_core_install/install_root/' | xargs rm -d || true
+    find os_core_install | sed -e 's/os_core_install/install_root/' | xargs rm -d &> /dev/null || true
 
 
 FROM clearlinux/os-core:latest

--- a/rabbitmq/Dockerfile
+++ b/rabbitmq/Dockerfile
@@ -26,7 +26,7 @@ RUN source /os-release && \
 RUN mkdir /os_core_install
 COPY --from=clearlinux/os-core:latest / /os_core_install/
 RUN cd / && \
-    find os_core_install | sed -e 's/os_core_install/install_root/' | xargs rm -d || true
+    find os_core_install | sed -e 's/os_core_install/install_root/' | xargs rm -d &> /dev/null || true
 
 FROM clearlinux/os-core:latest
 

--- a/redis/Dockerfile
+++ b/redis/Dockerfile
@@ -25,7 +25,7 @@ RUN source /os-release && \
 RUN mkdir /os_core_install
 COPY --from=clearlinux/os-core:latest / /os_core_install/
 RUN cd / && \
-    find os_core_install | sed -e 's/os_core_install/install_root/' | xargs rm -d || true
+    find os_core_install | sed -e 's/os_core_install/install_root/' | xargs rm -d &> /dev/null || true
 
 FROM clearlinux/os-core:latest
 MAINTAINER qi.zheng@intel.com

--- a/ruby/Dockerfile
+++ b/ruby/Dockerfile
@@ -26,7 +26,7 @@ RUN source /os-release && \
 RUN mkdir /os_core_install
 COPY --from=clearlinux/os-core:latest / /os_core_install/
 RUN cd / && \
-    find os_core_install | sed -e 's/os_core_install/install_root/' | xargs rm -d || true
+    find os_core_install | sed -e 's/os_core_install/install_root/' | xargs rm -d &> /dev/null || true
 
 FROM clearlinux/os-core:latest
 

--- a/tensorflow/Dockerfile
+++ b/tensorflow/Dockerfile
@@ -26,7 +26,7 @@ RUN source /os-release && \
 RUN mkdir /os_core_install
 COPY --from=clearlinux/os-core:latest / /os_core_install/
 RUN cd / && \
-    find os_core_install | sed -e 's/os_core_install/install_root/' | xargs rm -d || true
+    find os_core_install | sed -e 's/os_core_install/install_root/' | xargs rm -d &> /dev/null || true
 
 
 FROM clearlinux/os-core:latest


### PR DESCRIPTION
When removing the duplicated file and directory via rm -d,
if it's a non-empty directory, it will prompt the warning
message that the directory could not be removed becuase it
is not empty. This is as expectation, as there are other
files under the same diretory and we need to keep them.
Hide these warning message to avoid confusion.

Signed-off-by: Liu, Jianjun <jianjun.liu@intel.com>