### PR TITLE
Disable redis protected mode

### DIFF
--- a/redis/Dockerfile
+++ b/redis/Dockerfile
@@ -42,4 +42,4 @@ RUN chmod +x /usr/local/bin/docker-entrypoint.sh
 ENTRYPOINT ["docker-entrypoint.sh"]
 
 EXPOSE 6379
-CMD ["redis-server"]
+CMD ["--protected-mode no"]

--- a/redis/docker-entrypoint.sh
+++ b/redis/docker-entrypoint.sh
@@ -4,13 +4,12 @@ set -e
 # first arg is `-f` or `--some-option`
 # or first arg is `something.conf`
 if [ "${1#-}" != "$1" ] || [ "${1%.conf}" != "$1" ]; then
-	set -- redis-server "$@"
+    set -- redis-server "$@"
 fi
 
-# allow the container to be started with `--user`
+# change to redis user to run
 if [ "$1" = 'redis-server' -a "$(id -u)" = '0' ]; then
-	find . \! -user redis -exec chown redis '{}' +
-	echo "su redis -s /bin/bash -c \"$0 $@\"" | exec
+    echo "redis -s /bin/bash -c \"$0 $@\"" | xargs su
 fi
 
 exec "$@"


### PR DESCRIPTION
The redis on docker hub disabled protected mode in default.
To make clear redis be compatible, disable the protected mode
in default as well.

Signed-off-by: Qi Zheng <qi.zheng@intel.com>