### PR TITLE
Cleanup machine-learning RUN commands

### DIFF
--- a/machine-learning-ui/Dockerfile
+++ b/machine-learning-ui/Dockerfile
@@ -3,10 +3,9 @@ MAINTAINER william.douglas@intel.com
 
 ARG swupd_args
 
-RUN swupd update $swupd_args
-RUN swupd bundle-add machine-learning-web-ui
-
-RUN rm -rf /var/lib/swupd
+RUN swupd update --no-boot-update $swupd_args \
+    && swupd bundle-add machine-learning-web-ui \
+    && rm -rf /var/lib/swupd/*
 
 EXPOSE 8888
 

--- a/machine-learning-ui/README.md
+++ b/machine-learning-ui/README.md
@@ -21,7 +21,7 @@ docker pull clearlinux/machine-learning-ui
 Run the machine-learning-ui Container
 ----------------------------------
 ```
-docker run -it clearlinux/machine-learning-ui
+docker run -p 8888:8888 -it clearlinux/machine-learning-ui
 ```
 
 Environment Variables

--- a/machine-learning-ui/jupyter_notebook_config.py
+++ b/machine-learning-ui/jupyter_notebook_config.py
@@ -1,7 +1,7 @@
 c = get_config()
 c.ContentsManager.root_dir = "/root/"
 c.NotebookApp.allow_root = True
-c.NotebookApp.ip = '*'
+c.NotebookApp.ip = '0.0.0.0'
 c.NotebookApp.open_browser = False
 c.NotebookApp.port = 8888
 

--- a/machine-learning/Dockerfile
+++ b/machine-learning/Dockerfile
@@ -3,9 +3,8 @@ MAINTAINER marcos.simental.magana@intel.com
 
 ARG swupd_args
 
-RUN swupd update $swupd_args
-RUN swupd bundle-add machine-learning-basic R-basic R-extras
-
-RUN rm -rf /var/lib/swupd
+RUN swupd update --no-boot-update $swupd_args \
+    && swupd bundle-add machine-learning-basic R-basic R-extras \
+    && rm -rf /var/lib/swupd
 
 CMD 'bash'


### PR DESCRIPTION
Squash all RUN commands to a single line so that it results in a
single docker layer.  Adding a new RUN command to remove files
will result in the files not being visible in the container, but
users still carry the full weight of the "deleted" files.

Signed-off-by: Rusty Lynch <rusty.lynch@intel.com>