### PR TITLE
Use su-exec to run commands on entryponit

### DIFF
--- a/cassandra/Dockerfile
+++ b/cassandra/Dockerfile
@@ -15,7 +15,7 @@ RUN source /os-release && \
     mkdir /install_root \
     && swupd os-install -V ${VERSION_ID} \
     --path /install_root --statedir /swupd-state \
-    --bundles=cassandra,python2-basic,which --no-boot-update \
+    --bundles=cassandra,python2-basic,which,su-exec --no-boot-update \
     && rm -rf /install_root/var/lib/swupd/*
 
 # For some Host OS configuration with redirect_dir on,

--- a/cassandra/docker-entrypoint.sh
+++ b/cassandra/docker-entrypoint.sh
@@ -9,7 +9,7 @@ fi
 
 # allow the container to be started with `--user`
 if [ "$1" = 'cassandra' -a "$(id -u)" = '0' ]; then
-	exec su cassandra -s /bin/bash -c "$BASH_SOURCE" "$@"
+    exec su-exec cassandra "$BASH_SOURCE" "$@"
 fi
 
 _ip_address() {

--- a/elasticsearch/Dockerfile
+++ b/elasticsearch/Dockerfile
@@ -17,7 +17,7 @@ RUN source /os-release && \
     mkdir /install_root \
     && swupd os-install -V ${VERSION_ID} \
     --path /install_root --statedir /swupd-state \
-    --bundles=elasticsearch --no-boot-update
+    --bundles=elasticsearch,su-exec --no-boot-update
 
 # For some Host OS configuration with redirect_dir on,
 # extra data are saved on the upper layer when the same

--- a/elasticsearch/docker-entrypoint.sh
+++ b/elasticsearch/docker-entrypoint.sh
@@ -20,8 +20,7 @@ if [ "$1" = 'elasticsearch' -a "$(id -u)" = '0' ]; then
 		chown -R elasticsearch:elasticsearch "$path"
 	done
 	
-	# use tmp file to avoid multiple parameters issue on su -c
-	echo "elasticsearch  -s /bin/bash -c \"$0 $@\"" | xargs su
+    set -- su-exec elasticsearch "$@"
 fi
 
 # As argument is not related to elasticsearch,

--- a/mariadb/Dockerfile
+++ b/mariadb/Dockerfile
@@ -17,7 +17,7 @@ RUN source /os-release && \
     mkdir /install_root \
     && swupd os-install -V ${VERSION_ID} \
     --path /install_root --statedir /swupd-state \
-    --bundles=mariadb --no-boot-update \
+    --bundles=mariadb,su-exec --no-boot-update \
     && rm -rf /install_root/var/lib/swupd/*
 
 # For some Host OS configuration with redirect_dir on,

--- a/mariadb/docker-entrypoint.sh
+++ b/mariadb/docker-entrypoint.sh
@@ -70,7 +70,7 @@ if [ "$1" = 'mysqld' -a -z "$wantHelp" -a "$(id -u)" = '0' ]; then
 	DATADIR="$(_get_config 'datadir' "$@")"
 	mkdir -p "$DATADIR"
 	find "$DATADIR" \! -user mysql -exec chown mysql '{}' +
-	echo "mysql -s /bin/bash -c \"$0 $@\"" | xargs su
+    exec su-exec mysql "$BASH_SOURCE" "$@"
 fi
 
 if [ "$1" = 'mysqld' -a -z "$wantHelp" ]; then

--- a/memcached/Dockerfile
+++ b/memcached/Dockerfile
@@ -15,7 +15,7 @@ RUN source /os-release && \
     mkdir /install_root \
     && swupd os-install -V ${VERSION_ID} \
     --path /install_root --statedir /swupd-state \
-    --bundles=memcached --no-boot-update \
+    --bundles=memcached,su-exec --no-boot-update \
     && rm -rf /install_root/var/lib/swupd/*
 
 # For some Host OS configuration with redirect_dir on,

--- a/memcached/docker-entrypoint.sh
+++ b/memcached/docker-entrypoint.sh
@@ -7,7 +7,7 @@ if [ "${1#-}" != "$1" ]; then
 fi
 
 if [ "$1" = 'memcached' -a "$(id -u)" = '0' ]; then
-        echo "memcached -s /bin/bash -c \"$0 $@\"" | xargs su
+    exec su-exec memcached "$BASH_SOURCE" "$@"
 fi
 
 exec "$@"

--- a/postgres/Dockerfile
+++ b/postgres/Dockerfile
@@ -17,7 +17,7 @@ RUN source /os-release && \
     mkdir /install_root \
     && swupd os-install -V ${VERSION_ID} \
     --path /install_root --statedir /swupd-state \
-    --bundles=postgresql --no-boot-update
+    --bundles=postgresql,su-exec --no-boot-update
 
 # For some Host OS configuration with redirect_dir on,
 # extra data are saved on the upper layer when the same

--- a/postgres/bootstrap.sh
+++ b/postgres/bootstrap.sh
@@ -51,7 +51,7 @@ if [ "$1" = 'postgres' ] && [ "$(id -u)" = '0' ]; then
 	fi
         sed -i "s|#listen_addresses.*|listen_addresses = '*'|" /usr/share/postgresql/postgresql.conf.sample
 
-	exec su postgres -s /bin/bash -c "$BASH_SOURCE $@"
+    exec su-exec postgres "$BASH_SOURCE" "$@"
 fi
 
 if [ "$1" = 'postgres' ]; then

--- a/rabbitmq/Dockerfile
+++ b/rabbitmq/Dockerfile
@@ -17,7 +17,7 @@ RUN source /os-release && \
     mkdir /install_root \
     && swupd os-install -V ${VERSION_ID} \
     --path /install_root --statedir /swupd-state \
-    --bundles=os-core-update,rabbitmq-server --no-boot-update
+    --bundles=os-core-update,rabbitmq-server,su-exec --no-boot-update
 
 # For some Host OS configuration with redirect_dir on,
 # extra data are saved on the upper layer when the same

--- a/rabbitmq/docker-entrypoint.sh
+++ b/rabbitmq/docker-entrypoint.sh
@@ -90,7 +90,7 @@ if [[ "$1" == rabbitmq* ]] && [ "$(id -u)" = '0' ]; then
 		[ -n "$val" ] || continue
 		case "$conf" in
 			*_ssl_*file | ssl_*file )
-				if [ -f "$val" ] && ! echo "rabbitmq -s /bin/bash test -r \"$val\"" | xargs su; then
+				if [ -f "$val" ] && ! su-exec rabbitmq test -r "$val"; then
 					newFile="/tmp/rabbitmq-ssl/$conf.pem"
 					echo >&2
 					echo >&2 "WARNING: '$val' ($var) is not readable by rabbitmq ($(id rabbitmq)); copying to '$newFile'"
@@ -108,7 +108,7 @@ if [[ "$1" == rabbitmq* ]] && [ "$(id -u)" = '0' ]; then
 		find /var/lib/rabbitmq \! -user rabbitmq -exec chown rabbitmq '{}' +
 	fi
 
-	exec echo "rabbitmq -s /bin/bash \"$BASH_SOURCE\" \"$@\"" | xargs su
+    exec su-exec rabbitmq "$BASH_SOURCE" "$@"
 fi
 
 haveConfig=

--- a/redis/Dockerfile
+++ b/redis/Dockerfile
@@ -15,7 +15,7 @@ RUN source /os-release && \
     mkdir /install_root \
     && swupd os-install -V ${VERSION_ID} \
     --path /install_root --statedir /swupd-state \
-    --bundles=redis-native,findutils --no-boot-update \
+    --bundles=redis-native,findutils,su-exec --no-boot-update \
     && rm -rf /install_root/var/lib/swupd/*
 
 # For some Host OS configuration with redirect_dir on,

--- a/redis/docker-entrypoint.sh
+++ b/redis/docker-entrypoint.sh
@@ -9,7 +9,7 @@ fi
 
 # change to redis user to run
 if [ "$1" = 'redis-server' -a "$(id -u)" = '0' ]; then
-    echo "redis -s /bin/bash -c \"$0 $@\"" | xargs su
+    exec su-exec redis "$BASH_SOURCE" "$@"
 fi
 
 exec "$@"


### PR DESCRIPTION
With su-exec, make sure the SIGTERM upon docker stop
could be received by the running program thus causing
a clean stop/exit.

Signed-off-by: Qi Zheng <qi.zheng@intel.com> 

#181 
#184 