### PR TITLE
Remove clr-sdk from travis to avoid timeouts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ env:
   - DOCKERFILE_DIR=cassandra
   - DOCKERFILE_DIR=cgit
   - DOCKERFILE_DIR=clr-installer-ci
-  - DOCKERFILE_DIR=clr-sdk
   - DOCKERFILE_DIR=elasticsearch
   - DOCKERFILE_DIR=flink
   - DOCKERFILE_DIR=golang


### PR DESCRIPTION
Currently this isn't actively being worked on so having it being
tested just causes false positives due to timeouts building the
container. Look at adding it back once the build time can be reduced.