### PR TITLE
no swupd state data removing in 1st build stage

### DIFF
--- a/cassandra/Dockerfile
+++ b/cassandra/Dockerfile
@@ -15,8 +15,7 @@ RUN source /os-release && \
     mkdir /install_root \
     && swupd os-install -V ${VERSION_ID} \
     --path /install_root --statedir /swupd-state \
-    --bundles=cassandra,python2-basic,which,su-exec --no-boot-update \
-    && rm -rf /install_root/var/lib/swupd/*
+    --bundles=cassandra,python2-basic,which,su-exec --no-boot-update
 
 # For some Host OS configuration with redirect_dir on,
 # extra data are saved on the upper layer when the same

--- a/cgit/Dockerfile
+++ b/cgit/Dockerfile
@@ -15,8 +15,7 @@ RUN source /os-release && \
     mkdir /install_root \
     && swupd os-install -V ${VERSION_ID} \
     --path /install_root --statedir /swupd-state \
-    --bundles=sudo,curl,scm-server,httpd --no-boot-update \
-    && rm -rf /install_root/var/lib/swupd/*
+    --bundles=sudo,curl,scm-server,httpd --no-boot-update
 
 # For some Host OS configuration with redirect_dir on,
 # extra data are saved on the upper layer when the same

--- a/httpd/Dockerfile
+++ b/httpd/Dockerfile
@@ -15,8 +15,7 @@ RUN source /os-release && \
     mkdir /install_root \
     && swupd os-install -V ${VERSION_ID} \
     --path /install_root --statedir /swupd-state \
-    --bundles=httpd --no-boot-update \
-    && rm -rf /install_root/var/lib/swupd/*
+    --bundles=httpd --no-boot-update
 
 # For some Host OS configuration with redirect_dir on,
 # extra data are saved on the upper layer when the same

--- a/mariadb/Dockerfile
+++ b/mariadb/Dockerfile
@@ -17,8 +17,7 @@ RUN source /os-release && \
     mkdir /install_root \
     && swupd os-install -V ${VERSION_ID} \
     --path /install_root --statedir /swupd-state \
-    --bundles=mariadb,su-exec --no-boot-update \
-    && rm -rf /install_root/var/lib/swupd/*
+    --bundles=mariadb,su-exec --no-boot-update
 
 # For some Host OS configuration with redirect_dir on,
 # extra data are saved on the upper layer when the same

--- a/memcached/Dockerfile
+++ b/memcached/Dockerfile
@@ -15,8 +15,7 @@ RUN source /os-release && \
     mkdir /install_root \
     && swupd os-install -V ${VERSION_ID} \
     --path /install_root --statedir /swupd-state \
-    --bundles=memcached,su-exec --no-boot-update \
-    && rm -rf /install_root/var/lib/swupd/*
+    --bundles=memcached,su-exec --no-boot-update
 
 # For some Host OS configuration with redirect_dir on,
 # extra data are saved on the upper layer when the same

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -15,8 +15,7 @@ RUN source /os-release && \
     mkdir /install_root \
     && swupd os-install -V ${VERSION_ID} \
     --path /install_root --statedir /swupd-state \
-    --bundles=nginx --no-scripts \
-    && rm -rf /install_root/var/lib/swupd/*
+    --bundles=nginx --no-scripts
 
 # For some Host OS configuration with redirect_dir on,
 # extra data are saved on the upper layer when the same

--- a/os-core/Dockerfile
+++ b/os-core/Dockerfile
@@ -11,8 +11,7 @@ RUN source /usr/lib/os-release \
     && mkdir /install_root \
     && swupd os-install -V ${VERSION_ID} \
     --path /install_root --statedir /swupd-state \
-    --bundles=os-core --no-boot-update \
-    && rm -rf /install_root/var/lib/swupd/*
+    --bundles=os-core --no-boot-update
 
 FROM scratch
 COPY --from=builder /install_root /

--- a/redis/Dockerfile
+++ b/redis/Dockerfile
@@ -15,8 +15,7 @@ RUN source /os-release && \
     mkdir /install_root \
     && swupd os-install -V ${VERSION_ID} \
     --path /install_root --statedir /swupd-state \
-    --bundles=redis-native,findutils,su-exec --no-boot-update \
-    && rm -rf /install_root/var/lib/swupd/*
+    --bundles=redis-native,findutils,su-exec --no-boot-update
 
 # For some Host OS configuration with redirect_dir on,
 # extra data are saved on the upper layer when the same


### PR DESCRIPTION
During the 1st stage build of multi-stage build, when
run swupd os-install, the swupd state data are saved to
/swupd_state, which will not be copied to the target.
So we do not need to remove swupd state data.

Signed-off-by: Liu, Jianjun <jianjun.liu@intel.com>