### PR TITLE
Use --no-boot-update for nginx

### DIFF
--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -15,7 +15,7 @@ RUN source /os-release && \
     mkdir /install_root \
     && swupd os-install -V ${VERSION_ID} \
     --path /install_root --statedir /swupd-state \
-    --bundles=nginx --no-scripts
+    --bundles=nginx --no-boot-update
 
 # For some Host OS configuration with redirect_dir on,
 # extra data are saved on the upper layer when the same


### PR DESCRIPTION
Use --no-boot-update instead of --no-scripts for nginx.

Signed-off-by: Liu, Jianjun <jianjun.liu@intel.com>