### PR TITLE
add docker_entrypoint as official

### DIFF
--- a/node/Dockerfile
+++ b/node/Dockerfile
@@ -33,4 +33,9 @@ FROM clearlinux/os-core:latest
 
 COPY --from=builder /install_root /
 
+COPY docker-entrypoint.sh /usr/bin/
+RUN chmod +x /usr/bin/docker-entrypoint.sh
+
+ENTRYPOINT ["/usr/bin/docker-entrypoint.sh"]
+
 CMD ["node"]

--- a/node/docker-entrypoint.sh
+++ b/node/docker-entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -e
+
+if [ "${1#-}" != "${1}" ] || [ -z "$(command -v "${1}")" ]; then
+	  set -- node "$@"
+fi
+
+exec "$@"


### PR DESCRIPTION
Create link for /usr/bin/yarn, which is the same as the official
docker. Add docker_entrypoint.sh as official one.

Signed-off-by: Liu, Jianjun <jianjun.liu@intel.com>