### PR TITLE
Add DBRS dockerfiles

### DIFF
--- a/stacks/dbrs/README.md
+++ b/stacks/dbrs/README.md
@@ -1,0 +1,8 @@
+# Database Reference Stack
+
+This provides the Database Reference Stack.  To offer more flexibility, there are multiple versions of the Database Reference Stack:
+
+ * Cassandra optimized image featuring support for Intel® Optane™ DC persistent memory
+ * Redis optimized image featuring support for Intel® Optane™ DC persistent memory
+
+Please see the folders in this level about the variants and how to build and use them.

--- a/stacks/dbrs/cassandra/Dockerfile
+++ b/stacks/dbrs/cassandra/Dockerfile
@@ -1,0 +1,68 @@
+FROM clearlinux-base
+MAINTAINER otc-swstacks@intel.com
+
+RUN swupd bundle-add curl java-runtime python2-basic which pmdk sudo
+
+RUN mkdir workspace
+COPY scripts/docker-entrypoint.sh /usr/local/bin/
+COPY scripts/docker-healthcheck /usr/local/bin/
+COPY scripts/change_fsdax_perms.sh /usr/local/bin/
+COPY scripts/change_devdax_perms.sh /usr/local/bin/
+COPY scripts/change_persistent_dirs_perms.sh /usr/local/bin/
+
+#Adding sudo in order to take ownership of PMEM devices, sudoers file should be deleted
+#once the permissions are granted on docker-entrypoint.sh
+RUN  useradd cassandra-user && \
+     mkdir -p /etc/sudoers.d && \
+     echo 'cassandra-user ALL=(root) NOPASSWD: /usr/local/bin/change_fsdax_perms.sh,/usr/local/bin/change_devdax_perms.sh,/usr/local/bin/change_persistent_dirs_perms.sh' > /etc/sudoers.d/cassandra-user
+
+RUN  chown root:root /usr/local/bin/change_fsdax_perms.sh && \
+     chmod 755 /usr/local/bin/change_fsdax_perms.sh && \
+     chown root:root /usr/local/bin/change_devdax_perms.sh && \
+     chmod 755 /usr/local/bin/change_devdax_perms.sh && \
+     chown root:root /usr/local/bin/change_persistent_dirs_perms.sh && \
+     chmod 755 /usr/local/bin/change_persistent_dirs_perms.sh
+
+
+COPY cassandra-pmem-build.tar.gz /tmp
+RUN  cd /tmp && \
+     tar zxvf cassandra-pmem-build.tar.gz && \
+     mkdir -p /workspace/cassandra/build && \
+     cp -r /tmp/cassandra/bin /workspace/cassandra && \
+     cp -r /tmp/cassandra/conf /workspace/cassandra && \
+     cp -r /tmp/cassandra/lib /workspace/cassandra && \
+     cp -r /tmp/cassandra/pylib /workspace/cassandra && \
+     cp -r /tmp/cassandra/tools /workspace/cassandra && \
+     cp -r /tmp/cassandra/build/classes /workspace/cassandra/build && \
+     cd /workspace && \
+     rm -rf /tmp/cassandra && \
+     rm /tmp/cassandra-pmem-build.tar.gz && \
+     chown root:root -R /workspace && \
+     mkdir /workspace/cassandra/data && \
+     mkdir /workspace/cassandra/logs && \
+     chown cassandra-user -R /workspace/cassandra/data && \
+     chown cassandra-user -R /workspace/cassandra/logs && \
+     chmod 0755 /workspace/cassandra/bin/* && \
+     rm -rf /workspace/cassandra/lib/sigar-bin/*.dll && \
+     rm -rf /workspace/cassandra/lib/sigar-bin/*.lib && \
+     rm /workspace/cassandra/conf/cassandra.yaml && \
+     rm /workspace/cassandra/conf/jvm-server.options && \
+     rm /workspace/cassandra/conf/jvm8-server.options && \
+     rm /workspace/cassandra/conf/jvm11-server.options && \
+     rm /workspace/cassandra/lib/snappy-java-1.1.2.6.jar
+
+
+COPY conf/cassandra-template.yaml /workspace/cassandra/conf/
+COPY conf/jvm-server.options-template /workspace/cassandra/conf/
+COPY conf/jvm8-server.options /workspace/cassandra/conf/
+COPY conf/jvm11-server.options /workspace/cassandra/conf/
+RUN chown cassandra-user -R /workspace/cassandra/conf/
+
+RUN swupd bundle-remove curl
+RUN swupd clean
+
+HEALTHCHECK --interval=30s CMD ["docker-healthcheck"]
+
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
+USER cassandra-user
+CMD ["/workspace/cassandra/bin/cassandra", "-f"]

--- a/stacks/dbrs/cassandra/README.md
+++ b/stacks/dbrs/cassandra/README.md
@@ -1,0 +1,302 @@
+## Database Reference Stack with Cassandra
+
+[![](https://images.microbadger.com/badges/image/clearlinux/stacks-dbrs-cassandra.svg)](http://microbadger.com/images/clearlinux/stacks-dbrs-cassandra "Get your own image badge on microbadger.com")
+
+### Building Locally
+
+The Dockerfiles for all Clear Linux* OS based container images are available at [dockerfiles repository](https://github.com/clearlinux/dockerfiles). These can be used to build and modify the container images.
+
+1. Clone the clearlinux/dockerfiles repository.
+
+    ```bash
+    git clone https://github.com/clearlinux/dockerfiles.git
+    ```
+
+2. Change to the directory of the application:
+
+    ```bash
+    cd dockerfiles/stacks/dbrs/cassandra
+    ```
+
+3. Inside this repository there is a file called `scripts/build-cassandra-pmem.sh`, this script handles all the required procedures in rder to have cassandra-pmem compiled and ready for Dockerfile usage. The dependencies for this build can be installed with `swupd`.
+
+    ```bash
+    swupd bundle-add c-basic java-basic devpkg-pmdk pmdk
+    ```
+
+4. Once installed, we run the script
+
+    ```bash
+    ./scripts/build-cassandra-pmem.sh
+    ```
+
+5. If everything runs sucessfully you will have a file called `cassandra-pmem-build.tar.gz` on the directory on which you run the script, this file should be placed in the same directory of the Dockerfile for this one to be able to build the docker image sucesfully. Default build args in Docker are on: https://docs.docker.com/engine/reference/builder/#arg
+
+    ```bash
+    docker build --no-cache -t clearlinux/stacks-dbrs-cassandra .
+    ```
+
+### Run DBRS Cassandra as a standalone container
+
+- PMEM memory in `devdax` or `fsdax`  mode, the container image is able to handle both modes and depending on the PMEM mode, the mount points inside the container should be different.
+
+In order to make available `devdax` pmem devices inside the container you must use the `--device` directive, internally the container always uses `/dev/dax0.0`, so the mapping should be:
+
+```
+--device=/dev/<host-device>:/dev/dax0.0
+```
+
+In a similar fashion for `fsdax` we need the device to be mapped to `/mnt/pmem` inside the container:
+
+```
+--mount type=bind,source=<source-mount-point>,target=/mnt/pmem
+```
+
+#### Preparing PMEM for container use
+
+In the current state, the cassandra-pmem image is capable of using both `fsdax` and `devdax`, the necessary steps to configure the PMEM to work with cassandra are documented here.
+
+##### fsdax mode
+
+First we need to verify that our PMEM is on `fsdax` mode
+
+```
+# ndctl list -u
+{
+  "dev":"namespace0.0",
+  "mode":"fsdax",
+  "map":"mem",
+  "size":"4.00 GiB (4.29 GB)",
+  "sector_size":512,
+  "blockdev":"pmem0"
+}
+```
+
+if for some reason the device is not on `fsdax` mode you can run `ndctl create-namespace -fe <namespace-name>  --mode=fsdax` to reconfigure the namespace to the desired mode.
+Once the PMEM namespace is configured, a device named `/dev/pmem{0-9}` should appear then we need to proceed to create a filesystem on it. The filesystem could be `ext4` or `xfs`, for this example we are going to use `ext4`.
+
+```
+# mkfs.ext4 /dev/pmem0
+mke2fs 1.45.2 (27-May-2019)
+Creating filesystem with 1031680 4k blocks and 258048 inodes
+Filesystem UUID: 303c03f5-ac4e-4462-8bf9-bc6b0fae53fe
+Superblock backups stored on blocks:
+	32768, 98304, 163840, 229376, 294912, 819200, 884736
+
+Allocating group tables: done
+Writing inode tables: done
+Creating journal (16384 blocks): done
+Writing superblocks and filesystem accounting information: done
+```
+
+Once the filesystem was created, we need to mount it with the dax option
+
+```bash
+mount /dev/pmem0 /mnt/pmem -o dax
+```
+
+When using `fsdax` mode cassandra-pmem creates a pool file on the pmem mountpoint, so the `jvm.options` configuration should look like the text below:
+
+```
+-Dpmem_path=/mnt/pmem/cassandra_pool
+-Dpool_size=3221225472
+```
+
+Where
+
+- pmem_path is the path to the pool file, which should include the path itself and the file name
+- pool_size is the size of the pool file in bytes, if you are using the docker images provided here you can pass this value as an environment variable to the container runtime in Gb and the calculation is done automatically.
+
+Is important to notice is that when creating the filesystem in the pmem device certain amount of space of the device is used by the filesystem metadata so the pool_size should be smaller than the total pmem namespace size.
+When using the docker image provided here, the file `jvm.options` is automatically populated with the environment variables `CASSANDRA_PMEM_POOL_NAME` and `CASSANDRA_FSDAX_POOL_SIZE_GB`.
+
+##### devdax mode
+
+We need to verify if the device we want to use is in `devdax` mode
+
+```
+root@clear-pmem/home/development # ndctl create-namespace -fe namespace0.0  --mode=devdax
+{
+  "dev":"namespace0.0",
+  "mode":"devdax",
+  "map":"dev",
+  "size":"3.94 GiB (4.23 GB)",
+  "uuid":"cb738cc7-711d-4578-bebf-1f7ba02ca169",
+  "daxregion":{
+    "id":0,
+    "size":"3.94 GiB (4.23 GB)",
+    "align":2097152,
+    "devices":[
+      {
+        "chardev":"dax0.0",
+        "size":"3.94 GiB (4.23 GB)"
+      }
+    ]
+  },
+  "align":2097152
+}
+```
+
+if not, we can reconfigure it using `ndctl create-namespace -fe <namespace-name>  --mode=devdax`. Before using a `devdax` device we need to clear the device:
+
+```
+root@clear-pmem/home/development # pmempool rm -vaf /dev/dax0.0
+removed '/dev/dax0.0'
+```
+
+The `jvm.options` configuration for cassandra should look like the following:
+```
+-Dpmem_path=/dev/dax0.0
+-Dpool_size=0
+```
+
+Where
+
+- pmem_path is the `devdax` device.
+- pool_size=0 indicates to use the entire `devdax` device.
+
+When using the docker image provided here, the file `jvm.options` is automatically populated.
+
+#### Start container
+
+In `devdax` mode:
+
+```bash
+docker run --device=/<devdax-device>:/dev/dax0.0 --ulimit nofile=262144:262144 -p 9042:9042 -p 7000:7000 -it --name cassandra-test <image-id>
+```
+
+In `fsdax` mode:
+
+```bash
+docker run --mount type=bind,source=/<fsdax-mountpoint>,target=/mnt/pmem  --ulimit nofile=262144:262144 -p 9042:9042 -p 7000:7000 -it -e 'CASSANDRA_FSDAX_POOL_SIZE_GB=<fsdax-pool-size-in-gb>' --name cassandra-test <image-id>
+```
+
+#### Configure container
+
+##### Using environment variables
+
+By default the container listens on the primary container IP address, but if required, some parameters can be provided as environment variables using `--env`.
+
+| **Environment Variable** | **Description** |
+| --- | --- |
+| `CASSANDRA_CLUSTER_NAME` | Cassandra cluster name, by default `Cassandra Cluster` |
+| `CASSANDRA_LISTEN_ADDRESS` | Cassandra listen address |
+| `CASSANDRA_RPC_ADDRESS` | Cassandra RPC address |
+| `CASSANDRA_SEED_ADDRESSES` | A comma separated list of hosts in the cluster, if not provided, cassandra is going to run as a single node. |
+| `CASSANDRA_SNITCH` | The snitch type for the cluster, by default it is `SimpleSnitch`, for more complex snitches you can mount your own `cassandra-rackdc.properties` file. |
+| `LOCAL_JMX` | If set to `no` the JMX service will listen on all IP addresses, the default is `yes` and listens just on localhost 127.0.0.1 |
+| `JVM_OPTS` | When set you can pass additional arguments to the JVM for cassandra execution, for example for specifying memory heap sizes `JVM_OPTS=-Xms16G -Xmx16G -Xmn12G` |
+
+When using PMEM in `fsdax` mode, there are some parameters to control the allocation of memory:
+
+| Environment Variable | Description |
+| --- | --- |
+| `CASSANDRA_FSDAX_POOL_SIZE_GB` | The size of the fsdax pool in GB, if it is not specified the pool size is `1` |
+| `CASSANDRA_PMEM_POOL_NAME` | The filename of the pool created in PMEM, by default `cassandra_pool` |
+
+##### Using custom files
+
+For more complex deployments it is also possible to provide custom `cassandra.yaml` and `jvm.options` files as shown below:
+
+```
+docker run --mount type=bind,source=/<fsdax-mountpoint>,target=/mnt/pmem -it  --ulimit nofile=262144:262144 --mount type=bind,source=/<path-to-file>/cassandra.yaml,target=/workspace/cassandra/conf/cassandra.yaml --mount type=bind,source=/path-to-file>/jvm.options,target=/workspace/cassandra/conf/jvm.options --name cassandra-custom-files
+```
+
+#### Clustering
+
+For a simple two node cluster using PMEM in `fsdax` mode on both containers:
+
+##### Node 1
+
+- IP: 172.17.0.2
+- PMEM mountpoint: /mnt/pmem1
+
+```
+docker run --mount type=bind,source=/mnt/pmem1,target=/mnt/pmem  --ulimit nofile=262144:262144 -it -e 'CASSANDRA_FSDAX_POOL_SIZE_GB=2' -e 'CASSANDRA_SEED_ADDRESSES=172.17.0.2:7000,172.17.0.3:7000'  --name cassandra-node1 <image-id>
+```
+
+##### Node 2
+
+- IP: 172.17.0.3
+- PMEM mountpoint: /mnt/pmem2
+
+```
+docker run --mount type=bind,source=/mnt/pmem2,target=/mnt/pmem  --ulimit nofile=262144:262144 -it -e 'CASSANDRA_FSDAX_POOL_SIZE_GB=2' -e 'CASSANDRA_SEED_ADDRESSES=172.17.0.2:7000,172.17.0.3:7000'  --name cassandra-node2 <image-id>
+```
+
+Once both nodes are running eventually the gossip is settled and we can use `nodetool` on any of both containers to check cluster status.
+
+```
+docker exec -it <container-id> bash /workspace/cassandra/bin/nodetool status
+```
+
+The output should look similar to this:
+
+```
+Datacenter: datacenter1
+=======================
+Status=Up/Down
+|/ State=Normal/Leaving/Joining/Moving
+--  Address     Load       Tokens       Owns (effective)  Host ID                               Rack
+UN  172.17.0.3  0 bytes    256          100.0%            22387159-8192-41cf-8b6c-8bf0e1049eb7  rack1
+UN  172.17.0.2  0 bytes    256          100.0%            219b56ba-c07c-400b-a018-a5dc20edeb09  rack1
+
+```
+
+#### Data persistence
+
+By default the data written to cassandra can be accessed as long as the container exists. In order to persist the data a user can mount volumes or bind mounts on `/workspace/cassandra/data` and `/workspace/cassandra/logs`, in this way the data can still be accessed once the container is deleted.
+
+### Deploy DBRS Cassandra cluster on Kubernetes
+
+Many containerized workloads are deployed in clusters and orchestration software like Kubernetes, for this purpose the Helm chart located on `cassandra-pmem-helm` can be useful.
+
+#### Kubernetes installation
+
+To install Kubernetes in Clear Linux, follow the instructions in the Clear Linux's [Kubernetes Tutorial](https://docs.01.org/clearlinux/latest/tutorials/kubernetes.html)
+
+After setting up Kubernetes, you will need to enable it to support DCPMM suing the pmem-csi driver. To install the driver follow the instructions in the [pmem-csi repository](https://github.com/intel/pmem-csi) file.
+
+Then Kubernetes cluster must have [helm and tiller](https://helm.sh/) installed in order for the helm chart to deploy.
+
+#### Helm chart configuration
+
+In order to configure the cassandra pmem cluster some variables and values are provided. This values are set on `cassandra-pmem-helm/values.yaml`, those can also be modified according to your specific needs. A summary of those parameters is shown below:
+
+| **Value** | **Description** |
+| --- | --- |
+| clusterName | The cluster Name set across all deployed nodes |
+| replicaCount | The number of nodes in the cluster to be deployed |
+| image.repository | The address of the container registry where the cassandra-pmem image should be pulled |
+| image.tag | The tag of the image to be pulled during deployment |
+| image.name | The name of the image to be pulled during deployment |
+| pmem.containerPmemAllocation | The size of the persistent volume claim to be used as heap, it uses the storage class `pmem-csi-sc-ext4` from pmem-csi |
+| pmem.fsdaxPoolSizeInGB | The size of the fsdax pool to be created inside the persistent volume claim, in practice it shuld be `1G` less than pmem.containerPmemAllocation |
+| enablePersistence | If set to `true` K8s persistent volumes are deployed to store data and logs | 
+| persistentVolumes.logsVolumeSize | The size of the persistent volume used for storing logs on each node, the default is `4G` |
+| persistentVolumes.dataVolumeSize | The size of the persistent volume used for storing data on each node, the default is `4G` |
+| persistentVolumes.logsStorageClass | K8s storage class used by  the logs pvc |
+| persistentVolumes.dataStorageClass | K8s storage class used by  the data pvc |
+| provideCustomConfig | If set to `true`, it mounts all the files located on `<helm-chart-dir>/files/conf` on `/workspace/cassandra/conf` inside each container in order to provide a way to customize the deployment beyond the options provided here |
+| exposeJmxPort | When set to `true` it exposes the JMX port as part of the kubernetes headless service, it should be used together with `enableAdditionalFilesConfigMap` in order to provide authentication files needed for JMX when the remote connections are allowed, when set to `false` only local access through 127.0.0.1 is granted and no additional authentication is needed |
+| enableClientToolsPod | If set to `true`, an additional pod independent from the cluster is deployed, this pod contains various Cassandra client tools and mounts test profiles located under `<helm-chart-dir>/files/testProfiles` to `/testProfiles` inside the pod. This pod is useful to test and launch benchmarks |
+| enableAdditionalFilesConfigMap | When set to true, it takes the files located in `<helm-chart-dir>/files/additionalFiles` and mount them in `/etc/cassandra` inside the pods, some additional files for cassandra can be stored here, such as JMX auth files |
+| jvmOpts.enabled | If set to `true` the environment variable `JVM_OPTS` is overriden with the value provided on jvmOpts.value |
+| jvmOpts.value | Sets the value of the environment variable `JVM_OPTS`, in this way some java runtime configurations can be provided such as RAM heap usage |
+| resources.enabled | if set to `true`, the resource constraints are set on each pod using the values under resources.requests and resources.limits |
+| resources.requests.memory and resources.request.cpu | Initial resource allocation for each pod in the cluster |
+| resources.limits.memory and resources.limits.cpu | Limits for cpu and memory for each pod in the cluster |
+
+** **Important considerations when selecting volume sizes** **
+
+When selecting the `fsdax` pool file size, it is important to consider that when requesting a volume, certain amount of space is used by the filesystem metadata on that volume, therefore the available space turns out to be less than total amount specified, taking this into consideration the size of the fsdax pool file should be ~2G less than the total volume size requested.
+
+#### Helm chart deployment
+
+Once all the configurations are set, to install the chart inside a given Kubernetes cluster you must run:
+
+```bash
+helm install ./cassandra-pmem-helm
+```
+
+Eventually all the given nodes will be shown as running using `kubectl get pods`.

--- a/stacks/dbrs/cassandra/cassandra-pmem-helm/.helmignore
+++ b/stacks/dbrs/cassandra/cassandra-pmem-helm/.helmignore
@@ -1,0 +1,22 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/stacks/dbrs/cassandra/cassandra-pmem-helm/Chart.yaml
+++ b/stacks/dbrs/cassandra/cassandra-pmem-helm/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+appVersion: "1.0"
+description: A Helm chart for deploying Cassandra PMEM on K8s
+name: cassandra-pmem-helm
+version: 0.1.0

--- a/stacks/dbrs/cassandra/cassandra-pmem-helm/files/additionalFiles/jmxremote.access
+++ b/stacks/dbrs/cassandra/cassandra-pmem-helm/files/additionalFiles/jmxremote.access
@@ -1,0 +1,2 @@
+monitorRole readonly
+controlRole readwrite 

--- a/stacks/dbrs/cassandra/cassandra-pmem-helm/files/additionalFiles/jmxremote.password
+++ b/stacks/dbrs/cassandra/cassandra-pmem-helm/files/additionalFiles/jmxremote.password
@@ -1,0 +1,3 @@
+##Role       password
+monitorRole  testpass
+controlRole  testpass

--- a/stacks/dbrs/cassandra/cassandra-pmem-helm/files/conf/README.md
+++ b/stacks/dbrs/cassandra/cassandra-pmem-helm/files/conf/README.md
@@ -1,0 +1,3 @@
+# Configuration files
+When using `provideCustomConfig: true` in values.yaml, the files included in this directory are mounted as config files inside the pod, so 
+more complex configurations can be provided.

--- a/stacks/dbrs/cassandra/cassandra-pmem-helm/files/testProfiles/README.md
+++ b/stacks/dbrs/cassandra/cassandra-pmem-helm/files/testProfiles/README.md
@@ -1,0 +1,2 @@
+# Test profiles
+When using `enableClientToolsPod: true` in values.yaml, the test profiles located in this directory are mounted on `/testProfiles` inside the pod.

--- a/stacks/dbrs/cassandra/cassandra-pmem-helm/files/testProfiles/cqlstress-counter-example.yaml
+++ b/stacks/dbrs/cassandra/cassandra-pmem-helm/files/testProfiles/cqlstress-counter-example.yaml
@@ -1,0 +1,78 @@
+#
+# This is an example YAML profile for cassandra-stress
+#
+# insert data
+# cassandra-stress user profile=/home/jake/stress1.yaml ops(insert=1)
+#
+# read, using query simple1:
+# cassandra-stress profile=/home/jake/stress1.yaml ops(simple1=1)
+#
+# mixed workload (90/10)
+# cassandra-stress user profile=/home/jake/stress1.yaml ops(insert=1,simple1=9)
+
+
+#
+# Keyspace info
+#
+keyspace: stresscql
+
+#
+# The CQL for creating a keyspace (optional if it already exists)
+#
+keyspace_definition: |
+  CREATE KEYSPACE stresscql WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1};
+
+#
+# Table info
+#
+table: counttest
+
+#
+# The CQL for creating a table you wish to stress (optional if it already exists)
+#
+table_definition: |
+  CREATE TABLE counttest (
+        name text PRIMARY KEY,
+        count counter
+  ) WITH comment='A table of many types to test wide rows'
+
+#
+# Optional meta information on the generated columns in the above table
+# The min and max only apply to text and blob types
+# The distribution field represents the total unique population
+# distribution of that column across rows.  Supported types are
+# 
+#      EXP(min..max)                        An exponential distribution over the range [min..max]
+#      EXTREME(min..max,shape)              An extreme value (Weibull) distribution over the range [min..max]
+#      GAUSSIAN(min..max,stdvrng)           A gaussian/normal distribution, where mean=(min+max)/2, and stdev is (mean-min)/stdvrng
+#      GAUSSIAN(min..max,mean,stdev)        A gaussian/normal distribution, with explicitly defined mean and stdev
+#      UNIFORM(min..max)                    A uniform distribution over the range [min, max]
+#      FIXED(val)                           A fixed distribution, always returning the same value
+#      SEQ(min..max)                        A fixed sequence, returning values in the range min to max sequentially (starting based on seed), wrapping if necessary.
+#      Aliases: extr, gauss, normal, norm, weibull
+#
+#      If preceded by ~, the distribution is inverted
+# Defaults for all columns are size: uniform(4..8), population: uniform(1..100B), cluster: fixed(1)
+#
+
+columnspec:
+  - name: name
+    size: uniform(1..4)
+  - name: count
+    population: fixed(1)
+
+insert:
+  partitions: fixed(1)             # number of unique partitions to update in a single operation
+                                  # if batchcount > 1, multiple batches will be used but all partitions will
+                                  # occur in all batches (unless they finish early); only the row counts will vary
+  batchtype: LOGGED               # type of batch to use
+  select: fixed(1)/1              # uniform chance any single generated CQL row will be visited in a partition;
+                                  # generated for each partition independently, each time we visit it
+
+#
+# A list of queries you wish to run against the schema
+#
+queries:
+   simple1:
+      cql: select * from counttest where name = ?
+      fields: samerow             # samerow or multirow (select arguments from the same row, or randomly from all rows in the partition)

--- a/stacks/dbrs/cassandra/cassandra-pmem-helm/files/testProfiles/cqlstress-example.yaml
+++ b/stacks/dbrs/cassandra/cassandra-pmem-helm/files/testProfiles/cqlstress-example.yaml
@@ -1,0 +1,109 @@
+#
+# This is an example YAML profile for cassandra-stress
+#
+# insert data
+# cassandra-stress user profile=/home/jake/stress1.yaml ops(insert=1)
+#
+# read, using query simple1:
+# cassandra-stress profile=/home/jake/stress1.yaml ops(simple1=1)
+#
+# mixed workload (90/10)
+# cassandra-stress user profile=/home/jake/stress1.yaml ops(insert=1,simple1=9)
+
+
+#
+# Keyspace info
+#
+keyspace: stresscql
+
+#
+# The CQL for creating a keyspace (optional if it already exists)
+#
+keyspace_definition: |
+  CREATE KEYSPACE stresscql WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1};
+
+#
+# Table info
+#
+table: typestest
+
+#
+# The CQL for creating a table you wish to stress (optional if it already exists)
+#
+table_definition: |
+  CREATE TABLE typestest (
+        name text,
+        choice boolean,
+        date timestamp,
+        address inet,
+        dbl double,
+        lval bigint,
+        ival int,
+        uid timeuuid,
+        value blob,
+        PRIMARY KEY((name,choice), date, address, dbl, lval, ival, uid)
+  ) 
+    WITH compaction = { 'class':'LeveledCompactionStrategy' }
+#    AND compression = { 'sstable_compression' : '' }
+#    AND comment='A table of many types to test wide rows'
+
+#
+# Optional meta information on the generated columns in the above table
+# The min and max only apply to text and blob types
+# The distribution field represents the total unique population
+# distribution of that column across rows.  Supported types are
+# 
+#      EXP(min..max)                        An exponential distribution over the range [min..max]
+#      EXTREME(min..max,shape)              An extreme value (Weibull) distribution over the range [min..max]
+#      GAUSSIAN(min..max,stdvrng)           A gaussian/normal distribution, where mean=(min+max)/2, and stdev is (mean-min)/stdvrng
+#      GAUSSIAN(min..max,mean,stdev)        A gaussian/normal distribution, with explicitly defined mean and stdev
+#      UNIFORM(min..max)                    A uniform distribution over the range [min, max]
+#      FIXED(val)                           A fixed distribution, always returning the same value
+#      SEQ(min..max)                        A fixed sequence, returning values in the range min to max sequentially (starting based on seed), wrapping if necessary.
+#      Aliases: extr, gauss, normal, norm, weibull
+#
+#      If preceded by ~, the distribution is inverted
+#
+# Defaults for all columns are size: uniform(4..8), population: uniform(1..100B), cluster: fixed(1)
+#
+columnspec:
+  - name: name
+    size: uniform(1..10)
+    population: uniform(1..10)     # the range of unique values to select for the field (default is 100Billion)
+  - name: date
+    cluster: uniform(20..40)
+  - name: lval
+    population: gaussian(1..1000)
+    cluster: uniform(1..4)
+
+insert:
+  partitions: uniform(1..50)       # number of unique partitions to update in a single operation
+                                  # if batchcount > 1, multiple batches will be used but all partitions will
+                                  # occur in all batches (unless they finish early); only the row counts will vary
+  batchtype: LOGGED               # type of batch to use
+  select: uniform(1..10)/10       # uniform chance any single generated CQL row will be visited in a partition;
+                                  # generated for each partition independently, each time we visit it
+
+#
+# A list of queries you wish to run against the schema
+#
+queries:
+   simple1:
+      cql: select * from typestest where name = ? and choice = ? LIMIT 100
+      fields: samerow             # samerow or multirow (select arguments from the same row, or randomly from all rows in the partition)
+   range1:
+      cql: select * from typestest where name = ? and choice = ? and date >= ? LIMIT 100
+      fields: multirow            # samerow or multirow (select arguments from the same row, or randomly from all rows in the partition)
+
+
+#
+# A list of bulk read queries that analytics tools may perform against the schema
+# Each query will sweep an entire token range, page by page.
+#
+token_range_queries:
+  all_columns_tr_query:
+    columns: '*'
+    page_size: 5000
+
+  value_tr_query:
+    columns: value

--- a/stacks/dbrs/cassandra/cassandra-pmem-helm/files/testProfiles/cqlstress-insanity-example.yaml
+++ b/stacks/dbrs/cassandra/cassandra-pmem-helm/files/testProfiles/cqlstress-insanity-example.yaml
@@ -1,0 +1,89 @@
+#
+# This is an example YAML profile for cassandra-stress
+#
+# insert data
+# cassandra-stress user profile=/home/jake/stress1.yaml ops(insert=1)
+#
+# read, using query simple1:
+# cassandra-stress profile=/home/jake/stress1.yaml ops(simple1=1)
+#
+# mixed workload (90/10)
+# cassandra-stress user profile=/home/jake/stress1.yaml ops(insert=1,simple1=9)
+
+
+#
+# Keyspace info
+#
+keyspace: stresscql
+
+#
+# The CQL for creating a keyspace (optional if it already exists)
+#
+keyspace_definition: |
+  CREATE KEYSPACE stresscql WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1};
+
+#
+# Table info
+#
+table: insanitytest
+
+#
+# The CQL for creating a table you wish to stress (optional if it already exists)
+#
+table_definition: |
+  CREATE TABLE insanitytest (
+        name text,
+        choice boolean,
+        date timestamp,
+        address inet,
+        dbl double,
+        lval bigint,
+        fval float,
+        ival int,
+        uid timeuuid,
+        value blob,
+        PRIMARY KEY((name, choice), date)
+  ) WITH compaction = { 'class':'LeveledCompactionStrategy' }
+    AND comment='A table of many types to test wide rows and collections'
+
+#
+# Optional meta information on the generated columns in the above table
+# The min and max only apply to text and blob types
+# The distribution field represents the total unique population
+# distribution of that column across rows.  Supported types are
+# 
+#      EXP(min..max)                        An exponential distribution over the range [min..max]
+#      EXTREME(min..max,shape)              An extreme value (Weibull) distribution over the range [min..max]
+#      GAUSSIAN(min..max,stdvrng)           A gaussian/normal distribution, where mean=(min+max)/2, and stdev is (mean-min)/stdvrng
+#      GAUSSIAN(min..max,mean,stdev)        A gaussian/normal distribution, with explicitly defined mean and stdev
+#      UNIFORM(min..max)                    A uniform distribution over the range [min, max]
+#      FIXED(val)                           A fixed distribution, always returning the same value
+#      SEQ(min..max)                        A fixed sequence, returning values in the range min to max sequentially (starting based on seed), wrapping if necessary.
+#      Aliases: extr, gauss, normal, norm, weibull
+#
+#      If preceded by ~, the distribution is inverted
+#
+# Defaults for all columns are size: uniform(4..8), population: uniform(1..100B), cluster: fixed(1)
+#
+columnspec:
+  - name: date
+    cluster: gaussian(1..20)
+  - name: lval
+    population: fixed(1)
+
+
+insert:
+  partitions: fixed(1)             # number of unique partitions to update in a single operation
+                                  # if batchcount > 1, multiple batches will be used but all partitions will
+                                  # occur in all batches (unless they finish early); only the row counts will vary
+  batchtype: LOGGED               # type of batch to use
+  select: fixed(1)/1              # uniform chance any single generated CQL row will be visited in a partition;
+                                  # generated for each partition independently, each time we visit it
+
+#
+# A list of queries you wish to run against the schema
+#
+queries:
+   simple1:
+      cql: select * from insanitytest where name = ? and choice = ? LIMIT 100
+      fields: samerow             # samerow or multirow (select arguments from the same row, or randomly from all rows in the partition)

--- a/stacks/dbrs/cassandra/cassandra-pmem-helm/files/testProfiles/cqlstress-lwt-example.yaml
+++ b/stacks/dbrs/cassandra/cassandra-pmem-helm/files/testProfiles/cqlstress-lwt-example.yaml
@@ -1,0 +1,71 @@
+# Based on https://gist.github.com/tjake/8995058fed11d9921e31
+### DML ###
+
+# Keyspace Name
+keyspace: cqlstress_lwt_example
+
+# The CQL for creating a keyspace (optional if it already exists)
+keyspace_definition: |
+  CREATE KEYSPACE cqlstress_lwt_example WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 3};
+
+# Table name
+table: blogposts
+
+# The CQL for creating a table you wish to stress (optional if it already exists)
+table_definition: |
+  CREATE TABLE blogposts (
+        domain text,
+        published_date timeuuid,
+        url text,
+        author text,
+        title text,
+        body text,
+        PRIMARY KEY(domain, published_date)
+  ) WITH CLUSTERING ORDER BY (published_date DESC)
+    AND compaction = { 'class':'LeveledCompactionStrategy' }
+    AND comment='A table to hold blog posts'
+
+### Column Distribution Specifications ###
+
+columnspec:
+  - name: domain
+    size: gaussian(5..100)       #domain names are relatively short
+    population: uniform(1..10M)  #10M possible domains to pick from
+
+  - name: published_date
+    cluster: fixed(1000)         #under each domain we will have max 1000 posts
+
+  - name: url
+    size: uniform(30..300)
+
+  - name: title                  #titles shouldn't go beyond 200 chars
+    size: gaussian(10..200)
+
+  - name: author
+    size: uniform(5..20)         #author names should be short
+
+  - name: body
+    size: gaussian(100..5000)    #the body of the blog post can be long
+
+### Batch Ratio Distribution Specifications ###
+
+insert:
+  partitions: fixed(1)            # Our partition key is the domain so only insert one per batch
+
+  select:    fixed(1)/1000        # We have 1000 posts per domain so 1/1000 will allow 1 post per batch
+
+  batchtype: UNLOGGED             # Unlogged batches
+
+  condition: IF body = NULL       # LWT: Do not override
+
+
+#
+# A list of queries you wish to run against the schema
+#
+queries:
+   singlepost:
+      cql: select * from blogposts where domain = ? LIMIT 1
+      fields: samerow
+   timeline:
+      cql: select url, title, published_date from blogposts where domain = ? LIMIT 10
+      fields: samerow

--- a/stacks/dbrs/cassandra/cassandra-pmem-helm/templates/additionalFilesConfigMap.yaml
+++ b/stacks/dbrs/cassandra/cassandra-pmem-helm/templates/additionalFilesConfigMap.yaml
@@ -1,0 +1,11 @@
+{{- if and (.Files.Glob "files/additionalFiles/*") (.Values.enableAdditionalFilesConfigMap) }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-additional-files-configmap
+  labels:
+    app: {{printf "%s-%s" .Release.Name .Values.appLabelSuffix }}
+data: 
+  {{ (.Files.Glob "files/additionalFiles/*").AsConfig | nindent 2 }}
+{{- end }}
+

--- a/stacks/dbrs/cassandra/cassandra-pmem-helm/templates/clientToolsPodDeployment.yaml
+++ b/stacks/dbrs/cassandra/cassandra-pmem-helm/templates/clientToolsPodDeployment.yaml
@@ -1,0 +1,29 @@
+{{- if .Values.enableClientToolsPod }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Release.Name }}-client-tools-pod
+  labels:
+    {{- $appLabel := printf "%s-%s" .Release.Name .Values.appLabelSuffix }}
+    app: {{ $appLabel }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: {{ $appLabel }}
+  template:
+    metadata:
+      labels:
+        app: {{ $appLabel }}
+    spec:
+      containers:
+      - name: {{ .Release.Name }}-client-tools-pod
+        image: {{ .Values.clientToolsImage.repository  }}/{{ .Values.clientToolsImage.image  }}:{{ .Values.clientToolsImage.tag  }}
+        volumeMounts:
+          - name: test-profiles-volume
+            mountPath: /testProfiles
+      volumes:
+        - name: test-profiles-volume
+          configMap:
+            name: {{ .Release.Name }}-test-profiles-configmap
+{{- end }}

--- a/stacks/dbrs/cassandra/cassandra-pmem-helm/templates/configMap.yaml
+++ b/stacks/dbrs/cassandra/cassandra-pmem-helm/templates/configMap.yaml
@@ -1,0 +1,10 @@
+{{- if and (.Files.Glob "files/conf/*") (.Values.provideCustomConfig) }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-configmap
+  labels:
+    app: {{printf "%s-%s" .Release.Name .Values.appLabelSuffix }}
+data: 
+  {{ (.Files.Glob "files/conf/*").AsConfig | nindent 2 }}
+{{- end }}

--- a/stacks/dbrs/cassandra/cassandra-pmem-helm/templates/headlessService.yaml
+++ b/stacks/dbrs/cassandra/cassandra-pmem-helm/templates/headlessService.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Service
+metadata:
+  {{- $serviceName := printf "%s-cassandra-pmem-svc" .Release.Name  }}
+  name: {{ $serviceName }}
+  labels:
+    {{- $appLabel := printf "%s-%s" .Release.Name .Values.appLabelSuffix }}      
+    app: {{ $appLabel }}
+spec:
+  ports:
+  - port: 9042
+    name: cql
+  - port: 7000
+    name: inter-node 
+  {{- if .Values.exposeJmxPort }}
+  - port: 7199
+    name: jmx-port
+  {{- end }}
+  clusterIP: None
+  selector:
+    app: {{ $appLabel }}

--- a/stacks/dbrs/cassandra/cassandra-pmem-helm/templates/service.yaml
+++ b/stacks/dbrs/cassandra/cassandra-pmem-helm/templates/service.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.exposeClusterExternally }}
+apiVersion: v1
+kind: Service
+metadata:
+  {{- $serviceName := printf "%s-cassandra-pmem-service" .Release.Name  }}
+  name: {{ $serviceName }}
+  labels:
+    {{- $appLabelSvc := printf "%s-%s" .Release.Name .Values.appLabelSuffix }}
+    app: {{ $appLabelSvc }}
+spec:
+  nodePort: 30001
+  type: NodePort
+  ports:
+  - name: cql
+    port: 9042
+    targetPort: cql
+  - name: thrift
+    port: 30001
+    targetPort: thrift
+  selector:
+    app: {{ $appLabelSvc }}
+{{- end }}

--- a/stacks/dbrs/cassandra/cassandra-pmem-helm/templates/statefulSet.yaml
+++ b/stacks/dbrs/cassandra/cassandra-pmem-helm/templates/statefulSet.yaml
@@ -1,0 +1,124 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  {{- $statefulSetName := printf "%s-%s" .Release.Name .Values.statefulSetSuffix }}
+  name: {{ $statefulSetName }}
+spec:
+  selector:
+    matchLabels:
+      {{- $appLabel := printf "%s-%s" .Release.Name .Values.appLabelSuffix }}
+      app: {{ $appLabel }} # has to match .spec.template.metadata.labels
+  {{- $serviceName := printf "%s-cassandra-pmem-svc" .Release.Name  }}
+  serviceName: {{ $serviceName  }}
+  replicas: {{ .Values.replicaCount  }} # by default is 1
+  template:
+    metadata:
+      labels:
+        app: {{ $appLabel }} # has to match .spec.selector.matchLabels
+    spec:
+      terminationGracePeriodSeconds: 10
+      containers:
+      - name: cassandra-pmem
+        image: {{ .Values.image.repository  }}/{{ .Values.image.name  }}:{{ .Values.image.tag  }}
+        ports:
+        - containerPort: 9042
+          name: cql
+        - containerPort: 7000
+          name: inter-node
+        {{- if .Values.exposeJmxPort }}
+        - containerPort: 7199
+          name: jmx-port
+        {{- end }}
+        {{- if .Values.resources.enabled }}
+        resources:
+          requests:
+            memory: {{ .Values.resources.requests.memory }}
+            cpu: {{ .Values.resources.requests.cpu }}
+          limits:
+            memory: {{ .Values.resources.limits.memory }}
+            cpu: {{ .Values.resources.limits.cpu }}
+        {{- end }}
+        {{- if ( not .Values.provideCustomConfig ) }}
+        env:
+        - name: CASSANDRA_SEED_ADDRESSES
+          {{- $seedAddresses := "" }}
+          {{- $nodeNumber := .Values.replicaCount | int }}
+          {{- $releaseName := .Release.Name }}
+          {{- range $index, $value := until $nodeNumber }}
+          {{- $seedAddresses =  printf "%s%s-%d.%s:7000," $seedAddresses $statefulSetName $index $serviceName }}
+          {{- end}}
+          value: {{ $seedAddresses | quote }}
+        - name: CASSANDRA_CLUSTER_NAME
+          {{- $defaultClusterName := printf "%s-cassandra-pmem-k8s-cluster" .Release.Name }}
+          value: {{ .Values.clusterName  | default $defaultClusterName | quote }}
+        - name: CASSANDRA_FSDAX_POOL_SIZE_GB
+          value: {{ .Values.pmem.fsdaxPoolSizeInGB | default "3" | quote }}
+        {{- if .Values.exposeJmxPort }}
+        - name: LOCAL_JMX
+          value: "no"
+        {{- end }}
+        {{- if .Values.jvmOpts.enabled }}
+        - name: JVM_OPTS
+          value: {{ .Values.jvmOpts.value }}
+        {{- end }}
+        {{- end }}
+        volumeMounts:
+        {{- if and (.Files.Glob "files/conf/*") (.Values.provideCustomConfig) }} 
+        - name: config-volume
+          mountPath: /workspace/cassandra/conf
+        {{- end }}
+        {{- if and (.Files.Glob "files/additionalFiles/*") (.Values.enableAdditionalFilesConfigMap) }}
+        - name: additional-files-volume
+          mountPath: /etc/cassandra
+        {{- end }}
+        - name: cassandra-pmem-pvc
+          mountPath: /mnt/pmem
+        {{- if .Values.enablePersistence }}
+        - name: cassandra-data-pvc
+          mountPath: /workspace/cassandra/data
+        - name: cassandra-logs-pvc
+          mountPath: /workspace/cassandra/logs
+        {{- end }}
+      volumes:
+      {{- if and (.Files.Glob "files/conf/*") (.Values.provideCustomConfig) }}
+        - name: config-volume
+          configMap:
+            name: {{ .Release.Name }}-configmap
+      {{- end }}
+      {{- if and (.Files.Glob "files/additionalFiles/*") (.Values.enableAdditionalFilesConfigMap) }}
+        - name: additional-files-volume
+          configMap:
+            name: {{ .Release.Name }}-additional-files-configmap
+      {{- end }}
+  volumeClaimTemplates:
+  - metadata:
+      name: cassandra-pmem-pvc
+    spec:
+      accessModes: 
+      - ReadWriteOnce 
+      storageClassName: "pmem-csi-sc-ext4"
+      resources:
+        requests:
+          storage: {{ .Values.pmem.containerPmemAllocation  | default "4G" | quote }}
+  {{- if .Values.enablePersistence }}
+  - metadata:
+      name: cassandra-data-pvc
+    spec:
+      accessModes:
+      - ReadWriteOnce
+      storageClassName: {{ .Values.persistentVolumes.dataStorageClass | quote }}
+      resources:
+        requests:
+          storage: {{ .Values.persistentVolumes.dataVolumeSize  | default "2G" | quote }}
+  - metadata:
+      name: cassandra-logs-pvc
+    spec:
+      accessModes:
+      - ReadWriteOnce
+      storageClassName: {{ .Values.persistentVolumes.logsStorageClass | quote }}
+      resources:
+        requests:
+          storage: {{ .Values.persistentVolumes.logsVolumeSize  | default "2G" | quote }}
+  {{- end }}
+
+

--- a/stacks/dbrs/cassandra/cassandra-pmem-helm/templates/testProfilesConfigMap.yaml
+++ b/stacks/dbrs/cassandra/cassandra-pmem-helm/templates/testProfilesConfigMap.yaml
@@ -1,0 +1,10 @@
+{{- if and (.Files.Glob "files/testProfiles/*") (.Values.enableClientToolsPod) }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-test-profiles-configmap
+  labels:
+    app: {{printf "%s-%s" .Release.Name .Values.appLabelSuffix }}
+data: 
+  {{ (.Files.Glob "files/testProfiles/*").AsConfig | nindent 2 }}
+{{- end }}

--- a/stacks/dbrs/cassandra/cassandra-pmem-helm/values.yaml
+++ b/stacks/dbrs/cassandra/cassandra-pmem-helm/values.yaml
@@ -1,0 +1,72 @@
+clusterName: "cassandra-pmem-test-cluster"
+#replica count specfies how many nodes will be used when deploying the cassandra-pmem cluster
+replicaCount: 4
+statefulSetSuffix: cassandra-pmem-cluster
+appLabelSuffix: cassandra-pmem
+
+#If set to true, the JMX port is also exposed as part of the service
+#Please notice that exposing the port requires to setup authentication
+#this can be accomplished providing the files using "enableAdditionalFilesConfigMap: true"
+#The additional files inside <helm-chart-dir>/files/additionalFiles is mounted inside the pod
+#on /etc/cassandra so additional files such as auth files for JMX can be added, by default some basic testing files are provided 
+#for production-like configuration some additional configuration needs to be done
+exposeJmxPort: true
+enableAdditionalFilesConfigMap: true
+
+#If set to true a NodePort service will be deployed to expose the cluster externally
+exposeClusterExternally: false
+
+image:
+  repository: DOCKER_CASSANDRA_PMEM_REGISTRY
+  tag: latest
+  pullPolicy: IfNotPresent
+  name: CASSANDRA_IMAGE
+
+#Pool size should be ~ containerPmemAllocation - 2G, otherwise pmem cassandra wil fail allocating heap,
+#this is because filesystem metadata use a portion of the total space requested in the persisten volume claim
+pmem:
+  containerPmemAllocation: "4G"
+  fsdaxPoolSizeInGB: "3"
+
+#Non-Pmem resources to be used by each cassandra-pmem node
+resources:
+  enabled: true
+  requests:
+    memory: "5G"
+    cpu: "1"
+  limits:
+    memory: "6G"
+    cpu: "4"
+
+#Variable used to control JVM_OPTS for the pods
+jvmOpts: 
+  enabled: true
+  value: "-Xms4G -Xmx4G -Xmn2G"
+
+#If enablePersistence is set to false, the data and logs dir will be using no K8s persistent volumes
+#therefore the data on the cluster does not persist across container deletion and recreation, this option
+#is useful for testing purposes
+#
+#custom storage classes can be used for data and logs, on a real world scenario it is prefered 
+#to use two different local storage devices in order to avoid bottlenecks and high network load
+enablePersistence: true
+persistentVolumes:
+  logsVolumeSize: 4G
+  dataVolumeSize: 4G
+  logsStorageClass: K8S_LOCAL_STORAGE_CLASS
+  dataStorageClass: K8S_LOCAL_STORAGE_CLASS
+
+#When set to true, the chart mounts the files stored in <helm-chart-dir>/files/conf as a read-only volume mounted in /workspace/cassandra/conf inside the pods. More complex
+#configurations can be provided in this way
+provideCustomConfig: false
+
+#Enable deploying a cassandra image containing client tools to test against the main cluster
+#this image is run as an independent pod from the main deployment, also test profiles can be placed under
+#the directory <helm-chart-dir>/files/testProfiles and those are  mounted on /testProfiles inside the client tools pod
+enableClientToolsPod: true
+clientToolsImage:
+  repository: DOCKER_CLIENT_TOOLS_REGISTRY
+  tag: latest
+  pullPolicy: IfNotPresent
+  image: CLIENT_TOOLS_IMAGE
+

--- a/stacks/dbrs/cassandra/conf/cassandra-template.yaml
+++ b/stacks/dbrs/cassandra/conf/cassandra-template.yaml
@@ -1,0 +1,1180 @@
+# Cassandra storage config YAML
+
+# NOTE:
+#   See http://wiki.apache.org/cassandra/StorageConfiguration for
+#   full explanations of configuration directives
+# /NOTE
+
+# The name of the cluster. This is mainly used to prevent machines in
+# one logical cluster from joining another.
+#cluster_name: 'Test Cluster'
+
+# This defines the number of tokens randomly assigned to this node on the ring
+# The more tokens, relative to other nodes, the larger the proportion of data
+# that this node will store. You probably want all nodes to have the same number
+# of tokens assuming they have equal hardware capability.
+#
+# If you leave this unspecified, Cassandra will use the default of 1 token for legacy compatibility,
+# and will use the initial_token as described below.
+#
+# Specifying initial_token will override this setting on the node's initial start,
+# on subsequent starts, this setting will apply even if initial token is set.
+#
+# If you already have a cluster with 1 token per node, and wish to migrate to 
+# multiple tokens per node, see http://wiki.apache.org/cassandra/Operations
+num_tokens: 256
+
+# Triggers automatic allocation of num_tokens tokens for this node. The allocation
+# algorithm attempts to choose tokens in a way that optimizes replicated load over
+# the nodes in the datacenter for the replication strategy used by the specified
+# keyspace.
+#
+# The load assigned to each node will be close to proportional to its number of
+# vnodes.
+#
+# Only supported with the Murmur3Partitioner.
+# allocate_tokens_for_keyspace: KEYSPACE
+
+# initial_token allows you to specify tokens manually.  While you can use it with
+# vnodes (num_tokens > 1, above) -- in which case you should provide a 
+# comma-separated list -- it's primarily used when adding nodes to legacy clusters 
+# that do not have vnodes enabled.
+# initial_token:
+
+# See http://wiki.apache.org/cassandra/HintedHandoff
+# May either be "true" or "false" to enable globally
+hinted_handoff_enabled: true
+
+# When hinted_handoff_enabled is true, a black list of data centers that will not
+# perform hinted handoff
+# hinted_handoff_disabled_datacenters:
+#    - DC1
+#    - DC2
+
+# this defines the maximum amount of time a dead host will have hints
+# generated.  After it has been dead this long, new hints for it will not be
+# created until it has been seen alive and gone down again.
+max_hint_window_in_ms: 10800000 # 3 hours
+
+# Maximum throttle in KBs per second, per delivery thread.  This will be
+# reduced proportionally to the number of nodes in the cluster.  (If there
+# are two nodes in the cluster, each delivery thread will use the maximum
+# rate; if there are three, each will throttle to half of the maximum,
+# since we expect two nodes to be delivering hints simultaneously.)
+hinted_handoff_throttle_in_kb: 1024
+
+# Number of threads with which to deliver hints;
+# Consider increasing this number when you have multi-dc deployments, since
+# cross-dc handoff tends to be slower
+max_hints_delivery_threads: 2
+
+# Directory where Cassandra should store hints.
+# If not set, the default directory is $CASSANDRA_HOME/data/hints.
+# hints_directory: /var/lib/cassandra/hints
+
+# How often hints should be flushed from the internal buffers to disk.
+# Will *not* trigger fsync.
+hints_flush_period_in_ms: 10000
+
+# Maximum size for a single hints file, in megabytes.
+max_hints_file_size_in_mb: 128
+
+# Compression to apply to the hint files. If omitted, hints files
+# will be written uncompressed. LZ4, Snappy, and Deflate compressors
+# are supported.
+#hints_compression:
+#   - class_name: LZ4Compressor
+#     parameters:
+#         -
+
+# Maximum throttle in KBs per second, total. This will be
+# reduced proportionally to the number of nodes in the cluster.
+batchlog_replay_throttle_in_kb: 1024
+
+# Authentication backend, implementing IAuthenticator; used to identify users
+# Out of the box, Cassandra provides org.apache.cassandra.auth.{AllowAllAuthenticator,
+# PasswordAuthenticator}.
+#
+# - AllowAllAuthenticator performs no checks - set it to disable authentication.
+# - PasswordAuthenticator relies on username/password pairs to authenticate
+#   users. It keeps usernames and hashed passwords in system_auth.roles table.
+#   Please increase system_auth keyspace replication factor if you use this authenticator.
+#   If using PasswordAuthenticator, CassandraRoleManager must also be used (see below)
+authenticator: AllowAllAuthenticator
+
+# Authorization backend, implementing IAuthorizer; used to limit access/provide permissions
+# Out of the box, Cassandra provides org.apache.cassandra.auth.{AllowAllAuthorizer,
+# CassandraAuthorizer}.
+#
+# - AllowAllAuthorizer allows any action to any user - set it to disable authorization.
+# - CassandraAuthorizer stores permissions in system_auth.role_permissions table. Please
+#   increase system_auth keyspace replication factor if you use this authorizer.
+authorizer: AllowAllAuthorizer
+
+# Part of the Authentication & Authorization backend, implementing IRoleManager; used
+# to maintain grants and memberships between roles.
+# Out of the box, Cassandra provides org.apache.cassandra.auth.CassandraRoleManager,
+# which stores role information in the system_auth keyspace. Most functions of the
+# IRoleManager require an authenticated login, so unless the configured IAuthenticator
+# actually implements authentication, most of this functionality will be unavailable.
+#
+# - CassandraRoleManager stores role data in the system_auth keyspace. Please
+#   increase system_auth keyspace replication factor if you use this role manager.
+role_manager: CassandraRoleManager
+
+# Network authorization backend, implementing INetworkAuthorizer; used to restrict user
+# access to certain DCs
+# Out of the box, Cassandra provides org.apache.cassandra.auth.{AllowAllNetworkAuthorizer,
+# CassandraNetworkAuthorizer}.
+#
+# - AllowAllNetworkAuthorizer allows access to any DC to any user - set it to disable authorization.
+# - CassandraNetworkAuthorizer stores permissions in system_auth.network_permissions table. Please
+#   increase system_auth keyspace replication factor if you use this authorizer.
+network_authorizer: AllowAllNetworkAuthorizer
+
+# Validity period for roles cache (fetching granted roles can be an expensive
+# operation depending on the role manager, CassandraRoleManager is one example)
+# Granted roles are cached for authenticated sessions in AuthenticatedUser and
+# after the period specified here, become eligible for (async) reload.
+# Defaults to 2000, set to 0 to disable caching entirely.
+# Will be disabled automatically for AllowAllAuthenticator.
+roles_validity_in_ms: 2000
+
+# Refresh interval for roles cache (if enabled).
+# After this interval, cache entries become eligible for refresh. Upon next
+# access, an async reload is scheduled and the old value returned until it
+# completes. If roles_validity_in_ms is non-zero, then this must be
+# also.
+# Defaults to the same value as roles_validity_in_ms.
+# roles_update_interval_in_ms: 2000
+
+# Validity period for permissions cache (fetching permissions can be an
+# expensive operation depending on the authorizer, CassandraAuthorizer is
+# one example). Defaults to 2000, set to 0 to disable.
+# Will be disabled automatically for AllowAllAuthorizer.
+permissions_validity_in_ms: 2000
+
+# Refresh interval for permissions cache (if enabled).
+# After this interval, cache entries become eligible for refresh. Upon next
+# access, an async reload is scheduled and the old value returned until it
+# completes. If permissions_validity_in_ms is non-zero, then this must be
+# also.
+# Defaults to the same value as permissions_validity_in_ms.
+# permissions_update_interval_in_ms: 2000
+
+# Validity period for credentials cache. This cache is tightly coupled to
+# the provided PasswordAuthenticator implementation of IAuthenticator. If
+# another IAuthenticator implementation is configured, this cache will not
+# be automatically used and so the following settings will have no effect.
+# Please note, credentials are cached in their encrypted form, so while
+# activating this cache may reduce the number of queries made to the
+# underlying table, it may not  bring a significant reduction in the
+# latency of individual authentication attempts.
+# Defaults to 2000, set to 0 to disable credentials caching.
+credentials_validity_in_ms: 2000
+
+# Refresh interval for credentials cache (if enabled).
+# After this interval, cache entries become eligible for refresh. Upon next
+# access, an async reload is scheduled and the old value returned until it
+# completes. If credentials_validity_in_ms is non-zero, then this must be
+# also.
+# Defaults to the same value as credentials_validity_in_ms.
+# credentials_update_interval_in_ms: 2000
+
+# The partitioner is responsible for distributing groups of rows (by
+# partition key) across nodes in the cluster.  You should leave this
+# alone for new clusters.  The partitioner can NOT be changed without
+# reloading all data, so when upgrading you should set this to the
+# same partitioner you were already using.
+#
+# Besides Murmur3Partitioner, partitioners included for backwards
+# compatibility include RandomPartitioner, ByteOrderedPartitioner, and
+# OrderPreservingPartitioner.
+#
+partitioner: org.apache.cassandra.dht.Murmur3Partitioner
+
+# Directories where Cassandra should store data on disk. If multiple
+# directories are specified, Cassandra will spread data evenly across 
+# them by partitioning the token ranges.
+# If not set, the default directory is $CASSANDRA_HOME/data/data.
+# data_file_directories:
+#     - /var/lib/cassandra/data
+
+# commit log.  when running on magnetic HDD, this should be a
+# separate spindle than the data directories.
+# If not set, the default directory is $CASSANDRA_HOME/data/commitlog.
+# commitlog_directory: /var/lib/cassandra/commitlog
+
+# Enable / disable CDC functionality on a per-node basis. This modifies the logic used
+# for write path allocation rejection (standard: never reject. cdc: reject Mutation
+# containing a CDC-enabled table if at space limit in cdc_raw_directory).
+cdc_enabled: false
+
+# CommitLogSegments are moved to this directory on flush if cdc_enabled: true and the
+# segment contains mutations for a CDC-enabled table. This should be placed on a
+# separate spindle than the data directories. If not set, the default directory is
+# $CASSANDRA_HOME/data/cdc_raw.
+# cdc_raw_directory: /var/lib/cassandra/cdc_raw
+
+# Policy for data disk failures:
+#
+# die
+#   shut down gossip and client transports and kill the JVM for any fs errors or
+#   single-sstable errors, so the node can be replaced.
+#
+# stop_paranoid
+#   shut down gossip and client transports even for single-sstable errors,
+#   kill the JVM for errors during startup.
+#
+# stop
+#   shut down gossip and client transports, leaving the node effectively dead, but
+#   can still be inspected via JMX, kill the JVM for errors during startup.
+#
+# best_effort
+#    stop using the failed disk and respond to requests based on
+#    remaining available sstables.  This means you WILL see obsolete
+#    data at CL.ONE!
+#
+# ignore
+#    ignore fatal errors and let requests fail, as in pre-1.2 Cassandra
+disk_failure_policy: stop
+
+# Policy for commit disk failures:
+#
+# die
+#   shut down the node and kill the JVM, so the node can be replaced.
+#
+# stop
+#   shut down the node, leaving the node effectively dead, but
+#   can still be inspected via JMX.
+#
+# stop_commit
+#   shutdown the commit log, letting writes collect but
+#   continuing to service reads, as in pre-2.0.5 Cassandra
+#
+# ignore
+#   ignore fatal errors and let the batches fail
+commit_failure_policy: stop
+
+# Maximum size of the native protocol prepared statement cache
+#
+# Valid values are either "auto" (omitting the value) or a value greater 0.
+#
+# Note that specifying a too large value will result in long running GCs and possbily
+# out-of-memory errors. Keep the value at a small fraction of the heap.
+#
+# If you constantly see "prepared statements discarded in the last minute because
+# cache limit reached" messages, the first step is to investigate the root cause
+# of these messages and check whether prepared statements are used correctly -
+# i.e. use bind markers for variable parts.
+#
+# Do only change the default value, if you really have more prepared statements than
+# fit in the cache. In most cases it is not neccessary to change this value.
+# Constantly re-preparing statements is a performance penalty.
+#
+# Default value ("auto") is 1/256th of the heap or 10MB, whichever is greater
+prepared_statements_cache_size_mb:
+
+# Maximum size of the key cache in memory.
+#
+# Each key cache hit saves 1 seek and each row cache hit saves 2 seeks at the
+# minimum, sometimes more. The key cache is fairly tiny for the amount of
+# time it saves, so it's worthwhile to use it at large numbers.
+# The row cache saves even more time, but must contain the entire row,
+# so it is extremely space-intensive. It's best to only use the
+# row cache if you have hot rows or static rows.
+#
+# NOTE: if you reduce the size, you may not get you hottest keys loaded on startup.
+#
+# Default value is empty to make it "auto" (min(5% of Heap (in MB), 100MB)). Set to 0 to disable key cache.
+key_cache_size_in_mb:
+
+# Duration in seconds after which Cassandra should
+# save the key cache. Caches are saved to saved_caches_directory as
+# specified in this configuration file.
+#
+# Saved caches greatly improve cold-start speeds, and is relatively cheap in
+# terms of I/O for the key cache. Row cache saving is much more expensive and
+# has limited use.
+#
+# Default is 14400 or 4 hours.
+key_cache_save_period: 14400
+
+# Number of keys from the key cache to save
+# Disabled by default, meaning all keys are going to be saved
+# key_cache_keys_to_save: 100
+
+# Row cache implementation class name. Available implementations:
+#
+# org.apache.cassandra.cache.OHCProvider
+#   Fully off-heap row cache implementation (default).
+#
+# org.apache.cassandra.cache.SerializingCacheProvider
+#   This is the row cache implementation availabile
+#   in previous releases of Cassandra.
+# row_cache_class_name: org.apache.cassandra.cache.OHCProvider
+
+# Maximum size of the row cache in memory.
+# Please note that OHC cache implementation requires some additional off-heap memory to manage
+# the map structures and some in-flight memory during operations before/after cache entries can be
+# accounted against the cache capacity. This overhead is usually small compared to the whole capacity.
+# Do not specify more memory that the system can afford in the worst usual situation and leave some
+# headroom for OS block level cache. Do never allow your system to swap.
+#
+# Default value is 0, to disable row caching.
+row_cache_size_in_mb: 0
+
+# Duration in seconds after which Cassandra should save the row cache.
+# Caches are saved to saved_caches_directory as specified in this configuration file.
+#
+# Saved caches greatly improve cold-start speeds, and is relatively cheap in
+# terms of I/O for the key cache. Row cache saving is much more expensive and
+# has limited use.
+#
+# Default is 0 to disable saving the row cache.
+row_cache_save_period: 0
+
+# Number of keys from the row cache to save.
+# Specify 0 (which is the default), meaning all keys are going to be saved
+# row_cache_keys_to_save: 100
+
+# Maximum size of the counter cache in memory.
+#
+# Counter cache helps to reduce counter locks' contention for hot counter cells.
+# In case of RF = 1 a counter cache hit will cause Cassandra to skip the read before
+# write entirely. With RF > 1 a counter cache hit will still help to reduce the duration
+# of the lock hold, helping with hot counter cell updates, but will not allow skipping
+# the read entirely. Only the local (clock, count) tuple of a counter cell is kept
+# in memory, not the whole counter, so it's relatively cheap.
+#
+# NOTE: if you reduce the size, you may not get you hottest keys loaded on startup.
+#
+# Default value is empty to make it "auto" (min(2.5% of Heap (in MB), 50MB)). Set to 0 to disable counter cache.
+# NOTE: if you perform counter deletes and rely on low gcgs, you should disable the counter cache.
+counter_cache_size_in_mb:
+
+# Duration in seconds after which Cassandra should
+# save the counter cache (keys only). Caches are saved to saved_caches_directory as
+# specified in this configuration file.
+#
+# Default is 7200 or 2 hours.
+counter_cache_save_period: 7200
+
+# Number of keys from the counter cache to save
+# Disabled by default, meaning all keys are going to be saved
+# counter_cache_keys_to_save: 100
+
+# saved caches
+# If not set, the default directory is $CASSANDRA_HOME/data/saved_caches.
+# saved_caches_directory: /var/lib/cassandra/saved_caches
+
+# commitlog_sync may be either "periodic", "group", or "batch." 
+# 
+# When in batch mode, Cassandra won't ack writes until the commit log
+# has been flushed to disk.  Each incoming write will trigger the flush task.
+# commitlog_sync_batch_window_in_ms is a deprecated value. Previously it had
+# almost no value, and is being removed.
+#
+# commitlog_sync_batch_window_in_ms: 2
+#
+# group mode is similar to batch mode, where Cassandra will not ack writes
+# until the commit log has been flushed to disk. The difference is group
+# mode will wait up to commitlog_sync_group_window_in_ms between flushes.
+#
+# commitlog_sync_group_window_in_ms: 1000
+#
+# the default option is "periodic" where writes may be acked immediately
+# and the CommitLog is simply synced every commitlog_sync_period_in_ms
+# milliseconds.
+commitlog_sync: periodic
+commitlog_sync_period_in_ms: 10000
+
+# The size of the individual commitlog file segments.  A commitlog
+# segment may be archived, deleted, or recycled once all the data
+# in it (potentially from each columnfamily in the system) has been
+# flushed to sstables.
+#
+# The default size is 32, which is almost always fine, but if you are
+# archiving commitlog segments (see commitlog_archiving.properties),
+# then you probably want a finer granularity of archiving; 8 or 16 MB
+# is reasonable.
+# Max mutation size is also configurable via max_mutation_size_in_kb setting in
+# cassandra.yaml. The default is half the size commitlog_segment_size_in_mb * 1024.
+# This should be positive and less than 2048.
+#
+# NOTE: If max_mutation_size_in_kb is set explicitly then commitlog_segment_size_in_mb must
+# be set to at least twice the size of max_mutation_size_in_kb / 1024
+#
+commitlog_segment_size_in_mb: 32
+
+# Compression to apply to the commit log. If omitted, the commit log
+# will be written uncompressed.  LZ4, Snappy, and Deflate compressors
+# are supported.
+# commitlog_compression:
+#   - class_name: LZ4Compressor
+#     parameters:
+#         -
+
+# any class that implements the SeedProvider interface and has a
+# constructor that takes a Map<String, String> of parameters will do.
+#seed_provider:
+    # Addresses of hosts that are deemed contact points. 
+    # Cassandra nodes use this list of hosts to find each other and learn
+    # the topology of the ring.  You must change this if you are running
+    # multiple nodes!
+    # - class_name: org.apache.cassandra.locator.SimpleSeedProvider
+    #parameters:
+          # seeds is actually a comma-delimited list of addresses.
+          # Ex: "<ip1>,<ip2>,<ip3>"
+          #- seeds: "127.0.0.1:7000"
+
+# For workloads with more data than can fit in memory, Cassandra's
+# bottleneck will be reads that need to fetch data from
+# disk. "concurrent_reads" should be set to (16 * number_of_drives) in
+# order to allow the operations to enqueue low enough in the stack
+# that the OS and drives can reorder them. Same applies to
+# "concurrent_counter_writes", since counter writes read the current
+# values before incrementing and writing them back.
+#
+# On the other hand, since writes are almost never IO bound, the ideal
+# number of "concurrent_writes" is dependent on the number of cores in
+# your system; (8 * number_of_cores) is a good rule of thumb.
+concurrent_reads: 32
+concurrent_writes: 32
+concurrent_counter_writes: 32
+
+# For materialized view writes, as there is a read involved, so this should
+# be limited by the less of concurrent reads or concurrent writes.
+concurrent_materialized_view_writes: 32
+
+# Maximum memory to use for sstable chunk cache and buffer pooling.
+# 32MB of this are reserved for pooling buffers, the rest is used as an
+# cache that holds uncompressed sstable chunks.
+# Defaults to the smaller of 1/4 of heap or 512MB. This pool is allocated off-heap,
+# so is in addition to the memory allocated for heap. The cache also has on-heap
+# overhead which is roughly 128 bytes per chunk (i.e. 0.2% of the reserved size
+# if the default 64k chunk size is used).
+# Memory is only allocated when needed.
+# file_cache_size_in_mb: 512
+
+# Flag indicating whether to allocate on or off heap when the sstable buffer
+# pool is exhausted, that is when it has exceeded the maximum memory
+# file_cache_size_in_mb, beyond which it will not cache buffers but allocate on request.
+
+# buffer_pool_use_heap_if_exhausted: true
+
+# The strategy for optimizing disk read
+# Possible values are:
+# ssd (for solid state disks, the default)
+# spinning (for spinning disks)
+# disk_optimization_strategy: ssd
+
+# Total permitted memory to use for memtables. Cassandra will stop
+# accepting writes when the limit is exceeded until a flush completes,
+# and will trigger a flush based on memtable_cleanup_threshold
+# If omitted, Cassandra will set both to 1/4 the size of the heap.
+# memtable_heap_space_in_mb: 2048
+# memtable_offheap_space_in_mb: 2048
+
+# memtable_cleanup_threshold is deprecated. The default calculation
+# is the only reasonable choice. See the comments on  memtable_flush_writers
+# for more information.
+#
+# Ratio of occupied non-flushing memtable size to total permitted size
+# that will trigger a flush of the largest memtable. Larger mct will
+# mean larger flushes and hence less compaction, but also less concurrent
+# flush activity which can make it difficult to keep your disks fed
+# under heavy write load.
+#
+# memtable_cleanup_threshold defaults to 1 / (memtable_flush_writers + 1)
+# memtable_cleanup_threshold: 0.11
+
+# Specify the way Cassandra allocates and manages memtable memory.
+# Options are:
+#
+# heap_buffers
+#   on heap nio buffers
+#
+# offheap_buffers
+#   off heap (direct) nio buffers
+#
+# offheap_objects
+#    off heap objects
+memtable_allocation_type: heap_buffers
+
+# Total space to use for commit logs on disk.
+#
+# If space gets above this value, Cassandra will flush every dirty CF
+# in the oldest segment and remove it.  So a small total commitlog space
+# will tend to cause more flush activity on less-active columnfamilies.
+#
+# The default value is the smaller of 8192, and 1/4 of the total space
+# of the commitlog volume.
+#
+# commitlog_total_space_in_mb: 8192
+
+# This sets the number of memtable flush writer threads per disk
+# as well as the total number of memtables that can be flushed concurrently.
+# These are generally a combination of compute and IO bound.
+#
+# Memtable flushing is more CPU efficient than memtable ingest and a single thread
+# can keep up with the ingest rate of a whole server on a single fast disk
+# until it temporarily becomes IO bound under contention typically with compaction.
+# At that point you need multiple flush threads. At some point in the future
+# it may become CPU bound all the time.
+#
+# You can tell if flushing is falling behind using the MemtablePool.BlockedOnAllocation
+# metric which should be 0, but will be non-zero if threads are blocked waiting on flushing
+# to free memory.
+#
+# memtable_flush_writers defaults to two for a single data directory.
+# This means that two  memtables can be flushed concurrently to the single data directory.
+# If you have multiple data directories the default is one memtable flushing at a time
+# but the flush will use a thread per data directory so you will get two or more writers.
+#
+# Two is generally enough to flush on a fast disk [array] mounted as a single data directory.
+# Adding more flush writers will result in smaller more frequent flushes that introduce more
+# compaction overhead.
+#
+# There is a direct tradeoff between number of memtables that can be flushed concurrently
+# and flush size and frequency. More is not better you just need enough flush writers
+# to never stall waiting for flushing to free memory.
+#
+#memtable_flush_writers: 2
+
+# Total space to use for change-data-capture logs on disk.
+#
+# If space gets above this value, Cassandra will throw WriteTimeoutException
+# on Mutations including tables with CDC enabled. A CDCCompactor is responsible
+# for parsing the raw CDC logs and deleting them when parsing is completed.
+#
+# The default value is the min of 4096 mb and 1/8th of the total space
+# of the drive where cdc_raw_directory resides.
+# cdc_total_space_in_mb: 4096
+
+# When we hit our cdc_raw limit and the CDCCompactor is either running behind
+# or experiencing backpressure, we check at the following interval to see if any
+# new space for cdc-tracked tables has been made available. Default to 250ms
+# cdc_free_space_check_interval_ms: 250
+
+# A fixed memory pool size in MB for for SSTable index summaries. If left
+# empty, this will default to 5% of the heap size. If the memory usage of
+# all index summaries exceeds this limit, SSTables with low read rates will
+# shrink their index summaries in order to meet this limit.  However, this
+# is a best-effort process. In extreme conditions Cassandra may need to use
+# more than this amount of memory.
+index_summary_capacity_in_mb:
+
+# How frequently index summaries should be resampled.  This is done
+# periodically to redistribute memory from the fixed-size pool to sstables
+# proportional their recent read rates.  Setting to -1 will disable this
+# process, leaving existing index summaries at their current sampling level.
+index_summary_resize_interval_in_minutes: 60
+
+# Whether to, when doing sequential writing, fsync() at intervals in
+# order to force the operating system to flush the dirty
+# buffers. Enable this to avoid sudden dirty buffer flushing from
+# impacting read latencies. Almost always a good idea on SSDs; not
+# necessarily on platters.
+trickle_fsync: false
+trickle_fsync_interval_in_kb: 10240
+
+# TCP port, for commands and data
+# For security reasons, you should not expose this port to the internet.  Firewall it if needed.
+storage_port: 7000
+
+# SSL port, for legacy encrypted communication. This property is unused unless enabled in
+# server_encryption_options (see below). As of cassandra 4.0, this property is deprecated
+# as a single port can be used for either/both secure and insecure connections.
+# For security reasons, you should not expose this port to the internet. Firewall it if needed.
+ssl_storage_port: 7001
+
+# Address or interface to bind to and tell other Cassandra nodes to connect to.
+# You _must_ change this if you want multiple nodes to be able to communicate!
+#
+# Set listen_address OR listen_interface, not both.
+#
+# Leaving it blank leaves it up to InetAddress.getLocalHost(). This
+# will always do the Right Thing _if_ the node is properly configured
+# (hostname, name resolution, etc), and the Right Thing is to use the
+# address associated with the hostname (it might not be).
+#
+# Setting listen_address to 0.0.0.0 is always wrong.
+#
+#listen_address: localhost
+
+# Set listen_address OR listen_interface, not both. Interfaces must correspond
+# to a single address, IP aliasing is not supported.
+# listen_interface: eth0
+
+# If you choose to specify the interface by name and the interface has an ipv4 and an ipv6 address
+# you can specify which should be chosen using listen_interface_prefer_ipv6. If false the first ipv4
+# address will be used. If true the first ipv6 address will be used. Defaults to false preferring
+# ipv4. If there is only one address it will be selected regardless of ipv4/ipv6.
+# listen_interface_prefer_ipv6: false
+
+# Address to broadcast to other Cassandra nodes
+# Leaving this blank will set it to the same value as listen_address
+# broadcast_address: 1.2.3.4
+
+# When using multiple physical network interfaces, set this
+# to true to listen on broadcast_address in addition to
+# the listen_address, allowing nodes to communicate in both
+# interfaces.
+# Ignore this property if the network configuration automatically
+# routes  between the public and private networks such as EC2.
+# listen_on_broadcast_address: false
+
+# Internode authentication backend, implementing IInternodeAuthenticator;
+# used to allow/disallow connections from peer nodes.
+# internode_authenticator: org.apache.cassandra.auth.AllowAllInternodeAuthenticator
+
+# Whether to start the native transport server.
+# The address on which the native transport is bound is defined by rpc_address.
+start_native_transport: true
+# port for the CQL native transport to listen for clients on
+# For security reasons, you should not expose this port to the internet.  Firewall it if needed.
+native_transport_port: 9042
+# Enabling native transport encryption in client_encryption_options allows you to either use
+# encryption for the standard port or to use a dedicated, additional port along with the unencrypted
+# standard native_transport_port.
+# Enabling client encryption and keeping native_transport_port_ssl disabled will use encryption
+# for native_transport_port. Setting native_transport_port_ssl to a different value
+# from native_transport_port will use encryption for native_transport_port_ssl while
+# keeping native_transport_port unencrypted.
+# native_transport_port_ssl: 9142
+# The maximum threads for handling requests (note that idle threads are stopped
+# after 30 seconds so there is not corresponding minimum setting).
+# native_transport_max_threads: 128
+#
+# The maximum size of allowed frame. Frame (requests) larger than this will
+# be rejected as invalid. The default is 256MB. If you're changing this parameter,
+# you may want to adjust max_value_size_in_mb accordingly. This should be positive and less than 2048.
+# native_transport_max_frame_size_in_mb: 256
+
+# The maximum number of concurrent client connections.
+# The default is -1, which means unlimited.
+# native_transport_max_concurrent_connections: -1
+
+# The maximum number of concurrent client connections per source ip.
+# The default is -1, which means unlimited.
+# native_transport_max_concurrent_connections_per_ip: -1
+
+# The address or interface to bind the native transport server to.
+#
+# Set rpc_address OR rpc_interface, not both.
+#
+# Leaving rpc_address blank has the same effect as on listen_address
+# (i.e. it will be based on the configured hostname of the node).
+#
+# Note that unlike listen_address, you can specify 0.0.0.0, but you must also
+# set broadcast_rpc_address to a value other than 0.0.0.0.
+#
+# For security reasons, you should not expose this port to the internet.  Firewall it if needed.
+#rpc_address: localhost
+
+# Set rpc_address OR rpc_interface, not both. Interfaces must correspond
+# to a single address, IP aliasing is not supported.
+# rpc_interface: eth1
+
+# If you choose to specify the interface by name and the interface has an ipv4 and an ipv6 address
+# you can specify which should be chosen using rpc_interface_prefer_ipv6. If false the first ipv4
+# address will be used. If true the first ipv6 address will be used. Defaults to false preferring
+# ipv4. If there is only one address it will be selected regardless of ipv4/ipv6.
+# rpc_interface_prefer_ipv6: false
+
+# RPC address to broadcast to drivers and other Cassandra nodes. This cannot
+# be set to 0.0.0.0. If left blank, this will be set to the value of
+# rpc_address. If rpc_address is set to 0.0.0.0, broadcast_rpc_address must
+# be set.
+# broadcast_rpc_address: 1.2.3.4
+
+# enable or disable keepalive on rpc/native connections
+rpc_keepalive: true
+
+# Uncomment to set socket buffer size for internode communication
+# Note that when setting this, the buffer size is limited by net.core.wmem_max
+# and when not setting it it is defined by net.ipv4.tcp_wmem
+# See also:
+# /proc/sys/net/core/wmem_max
+# /proc/sys/net/core/rmem_max
+# /proc/sys/net/ipv4/tcp_wmem
+# /proc/sys/net/ipv4/tcp_wmem
+# and 'man tcp'
+# internode_send_buff_size_in_bytes:
+
+# Uncomment to set socket buffer size for internode communication
+# Note that when setting this, the buffer size is limited by net.core.wmem_max
+# and when not setting it it is defined by net.ipv4.tcp_wmem
+# internode_recv_buff_size_in_bytes:
+
+# Set to true to have Cassandra create a hard link to each sstable
+# flushed or streamed locally in a backups/ subdirectory of the
+# keyspace data.  Removing these links is the operator's
+# responsibility.
+incremental_backups: false
+
+# Whether or not to take a snapshot before each compaction.  Be
+# careful using this option, since Cassandra won't clean up the
+# snapshots for you.  Mostly useful if you're paranoid when there
+# is a data format change.
+snapshot_before_compaction: false
+
+# Whether or not a snapshot is taken of the data before keyspace truncation
+# or dropping of column families. The STRONGLY advised default of true 
+# should be used to provide data safety. If you set this flag to false, you will
+# lose data on truncation or drop.
+auto_snapshot: true
+
+# Granularity of the collation index of rows within a partition.
+# Increase if your rows are large, or if you have a very large
+# number of rows per partition.  The competing goals are these:
+#
+# - a smaller granularity means more index entries are generated
+#   and looking up rows withing the partition by collation column
+#   is faster
+# - but, Cassandra will keep the collation index in memory for hot
+#   rows (as part of the key cache), so a larger granularity means
+#   you can cache more hot rows
+column_index_size_in_kb: 64
+
+# Per sstable indexed key cache entries (the collation index in memory
+# mentioned above) exceeding this size will not be held on heap.
+# This means that only partition information is held on heap and the
+# index entries are read from disk.
+#
+# Note that this size refers to the size of the
+# serialized index information and not the size of the partition.
+column_index_cache_size_in_kb: 2
+
+# Number of simultaneous compactions to allow, NOT including
+# validation "compactions" for anti-entropy repair.  Simultaneous
+# compactions can help preserve read performance in a mixed read/write
+# workload, by mitigating the tendency of small sstables to accumulate
+# during a single long running compactions. The default is usually
+# fine and if you experience problems with compaction running too
+# slowly or too fast, you should look at
+# compaction_throughput_mb_per_sec first.
+#
+# concurrent_compactors defaults to the smaller of (number of disks,
+# number of cores), with a minimum of 2 and a maximum of 8.
+# 
+# If your data directories are backed by SSD, you should increase this
+# to the number of cores.
+#concurrent_compactors: 1
+
+# Number of simultaneous repair validations to allow. Default is unbounded
+# Values less than one are interpreted as unbounded (the default)
+# concurrent_validations: 0
+
+# Number of simultaneous materialized view builder tasks to allow.
+concurrent_materialized_view_builders: 1
+
+# Throttles compaction to the given total throughput across the entire
+# system. The faster you insert data, the faster you need to compact in
+# order to keep the sstable count down, but in general, setting this to
+# 16 to 32 times the rate you are inserting data is more than sufficient.
+# Setting this to 0 disables throttling. Note that this account for all types
+# of compaction, including validation compaction.
+compaction_throughput_mb_per_sec: 16
+
+# When compacting, the replacement sstable(s) can be opened before they
+# are completely written, and used in place of the prior sstables for
+# any range that has been written. This helps to smoothly transfer reads 
+# between the sstables, reducing page cache churn and keeping hot rows hot
+sstable_preemptive_open_interval_in_mb: 50
+
+# Throttles all outbound streaming file transfers on this node to the
+# given total throughput in Mbps. This is necessary because Cassandra does
+# mostly sequential IO when streaming data during bootstrap or repair, which
+# can lead to saturating the network connection and degrading rpc performance.
+# When unset, the default is 200 Mbps or 25 MB/s.
+# stream_throughput_outbound_megabits_per_sec: 200
+
+# Throttles all streaming file transfer between the datacenters,
+# this setting allows users to throttle inter dc stream throughput in addition
+# to throttling all network stream traffic as configured with
+# stream_throughput_outbound_megabits_per_sec
+# When unset, the default is 200 Mbps or 25 MB/s
+# inter_dc_stream_throughput_outbound_megabits_per_sec: 200
+
+# How long the coordinator should wait for read operations to complete.
+# Lowest acceptable value is 10 ms.
+read_request_timeout_in_ms: 5000
+# How long the coordinator should wait for seq or index scans to complete.
+# Lowest acceptable value is 10 ms.
+range_request_timeout_in_ms: 10000
+# How long the coordinator should wait for writes to complete.
+# Lowest acceptable value is 10 ms.
+write_request_timeout_in_ms: 2000
+# How long the coordinator should wait for counter writes to complete.
+# Lowest acceptable value is 10 ms.
+counter_write_request_timeout_in_ms: 5000
+# How long a coordinator should continue to retry a CAS operation
+# that contends with other proposals for the same row.
+# Lowest acceptable value is 10 ms.
+cas_contention_timeout_in_ms: 1000
+# How long the coordinator should wait for truncates to complete
+# (This can be much longer, because unless auto_snapshot is disabled
+# we need to flush first so we can snapshot before removing the data.)
+# Lowest acceptable value is 10 ms.
+truncate_request_timeout_in_ms: 60000
+# The default timeout for other, miscellaneous operations.
+# Lowest acceptable value is 10 ms.
+request_timeout_in_ms: 10000
+
+# How long before a node logs slow queries. Select queries that take longer than
+# this timeout to execute, will generate an aggregated log message, so that slow queries
+# can be identified. Set this value to zero to disable slow query logging.
+slow_query_log_timeout_in_ms: 500
+
+# Enable operation timeout information exchange between nodes to accurately
+# measure request timeouts.  If disabled, replicas will assume that requests
+# were forwarded to them instantly by the coordinator, which means that
+# under overload conditions we will waste that much extra time processing 
+# already-timed-out requests.
+#
+# Warning: before enabling this property make sure to ntp is installed
+# and the times are synchronized between the nodes.
+cross_node_timeout: false
+
+# Set keep-alive period for streaming
+# This node will send a keep-alive message periodically with this period.
+# If the node does not receive a keep-alive message from the peer for
+# 2 keep-alive cycles the stream session times out and fail
+# Default value is 300s (5 minutes), which means stalled stream
+# times out in 10 minutes by default
+# streaming_keep_alive_period_in_secs: 300
+
+# Limit number of connections per host for streaming
+# Increase this when you notice that joins are CPU-bound rather that network
+# bound (for example a few nodes with big files).
+# streaming_connections_per_host: 1
+
+
+# phi value that must be reached for a host to be marked down.
+# most users should never need to adjust this.
+# phi_convict_threshold: 8
+
+# endpoint_snitch -- Set this to a class that implements
+# IEndpointSnitch.  The snitch has two functions:
+#
+# - it teaches Cassandra enough about your network topology to route
+#   requests efficiently
+# - it allows Cassandra to spread replicas around your cluster to avoid
+#   correlated failures. It does this by grouping machines into
+#   "datacenters" and "racks."  Cassandra will do its best not to have
+#   more than one replica on the same "rack" (which may not actually
+#   be a physical location)
+#
+# CASSANDRA WILL NOT ALLOW YOU TO SWITCH TO AN INCOMPATIBLE SNITCH
+# ONCE DATA IS INSERTED INTO THE CLUSTER.  This would cause data loss.
+# This means that if you start with the default SimpleSnitch, which
+# locates every node on "rack1" in "datacenter1", your only options
+# if you need to add another datacenter are GossipingPropertyFileSnitch
+# (and the older PFS).  From there, if you want to migrate to an
+# incompatible snitch like Ec2Snitch you can do it by adding new nodes
+# under Ec2Snitch (which will locate them in a new "datacenter") and
+# decommissioning the old ones.
+#
+# Out of the box, Cassandra provides:
+#
+# SimpleSnitch:
+#    Treats Strategy order as proximity. This can improve cache
+#    locality when disabling read repair.  Only appropriate for
+#    single-datacenter deployments.
+#
+# GossipingPropertyFileSnitch
+#    This should be your go-to snitch for production use.  The rack
+#    and datacenter for the local node are defined in
+#    cassandra-rackdc.properties and propagated to other nodes via
+#    gossip.  If cassandra-topology.properties exists, it is used as a
+#    fallback, allowing migration from the PropertyFileSnitch.
+#
+# PropertyFileSnitch:
+#    Proximity is determined by rack and data center, which are
+#    explicitly configured in cassandra-topology.properties.
+#
+# Ec2Snitch:
+#    Appropriate for EC2 deployments in a single Region. Loads Region
+#    and Availability Zone information from the EC2 API. The Region is
+#    treated as the datacenter, and the Availability Zone as the rack.
+#    Only private IPs are used, so this will not work across multiple
+#    Regions.
+#
+# Ec2MultiRegionSnitch:
+#    Uses public IPs as broadcast_address to allow cross-region
+#    connectivity.  (Thus, you should set seed addresses to the public
+#    IP as well.) You will need to open the storage_port or
+#    ssl_storage_port on the public IP firewall.  (For intra-Region
+#    traffic, Cassandra will switch to the private IP after
+#    establishing a connection.)
+#
+# RackInferringSnitch:
+#    Proximity is determined by rack and data center, which are
+#    assumed to correspond to the 3rd and 2nd octet of each node's IP
+#    address, respectively.  Unless this happens to match your
+#    deployment conventions, this is best used as an example of
+#    writing a custom Snitch class and is provided in that spirit.
+#
+# You can use a custom Snitch by setting this to the full class name
+# of the snitch, which will be assumed to be on your classpath.
+#endpoint_snitch: SimpleSnitch
+
+# controls how often to perform the more expensive part of host score
+# calculation
+dynamic_snitch_update_interval_in_ms: 100 
+# controls how often to reset all host scores, allowing a bad host to
+# possibly recover
+dynamic_snitch_reset_interval_in_ms: 600000
+# if set greater than zero, this will allow
+# 'pinning' of replicas to hosts in order to increase cache capacity.
+# The badness threshold will control how much worse the pinned host has to be
+# before the dynamic snitch will prefer other replicas over it.  This is
+# expressed as a double which represents a percentage.  Thus, a value of
+# 0.2 means Cassandra would continue to prefer the static snitch values
+# until the pinned host was 20% worse than the fastest.
+dynamic_snitch_badness_threshold: 0.1
+
+# Enable or disable inter-node encryption
+# JVM and netty defaults for supported SSL socket protocols and cipher suites can
+# be replaced using custom encryption options. This is not recommended
+# unless you have policies in place that dictate certain settings, or
+# need to disable vulnerable ciphers or protocols in case the JVM cannot
+# be updated.
+# FIPS compliant settings can be configured at JVM level and should not
+# involve changing encryption settings here:
+# https://docs.oracle.com/javase/8/docs/technotes/guides/security/jsse/FIPS.html
+#
+# *NOTE* No custom encryption options are enabled at the moment
+# The available internode options are : all, none, dc, rack
+# If set to dc cassandra will encrypt the traffic between the DCs
+# If set to rack cassandra will encrypt the traffic between the racks
+#
+# The passwords used in these options must match the passwords used when generating
+# the keystore and truststore.  For instructions on generating these files, see:
+# http://download.oracle.com/javase/8/docs/technotes/guides/security/jsse/JSSERefGuide.html#CreateKeystore
+#
+server_encryption_options:
+    # set to true for allowing secure incoming connections
+    enabled: false
+    # If enabled and optional are both set to true, encrypted and unencrypted connections are handled on the storage_port
+    optional: false
+    # if enabled, will open up an encrypted listening socket on ssl_storage_port. Should be used
+    # during upgrade to 4.0; otherwise, set to false.
+    enable_legacy_ssl_storage_port: false
+    # on outbound connections, determine which type of peers to securely connect to. 'enabled' must be set to true.
+    internode_encryption: none
+    keystore: conf/.keystore
+    keystore_password: cassandra
+    truststore: conf/.truststore
+    truststore_password: cassandra
+    # More advanced defaults below:
+    # protocol: TLS
+    # store_type: JKS
+    # cipher_suites: [TLS_RSA_WITH_AES_128_CBC_SHA,TLS_RSA_WITH_AES_256_CBC_SHA,TLS_DHE_RSA_WITH_AES_128_CBC_SHA,TLS_DHE_RSA_WITH_AES_256_CBC_SHA,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA]
+    # require_client_auth: false
+    # require_endpoint_verification: false
+
+# enable or disable client-to-server encryption.
+client_encryption_options:
+    enabled: false
+    # If enabled and optional is set to true encrypted and unencrypted connections are handled.
+    optional: false
+    keystore: conf/.keystore
+    keystore_password: cassandra
+    # require_client_auth: false
+    # Set trustore and truststore_password if require_client_auth is true
+    # truststore: conf/.truststore
+    # truststore_password: cassandra
+    # More advanced defaults below:
+    # protocol: TLS
+    # store_type: JKS
+    # cipher_suites: [TLS_RSA_WITH_AES_128_CBC_SHA,TLS_RSA_WITH_AES_256_CBC_SHA,TLS_DHE_RSA_WITH_AES_128_CBC_SHA,TLS_DHE_RSA_WITH_AES_256_CBC_SHA,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA]
+
+# internode_compression controls whether traffic between nodes is
+# compressed.
+# Can be:
+#
+# all
+#   all traffic is compressed
+#
+# dc
+#   traffic between different datacenters is compressed
+#
+# none
+#   nothing is compressed.
+internode_compression: dc
+
+# Enable or disable tcp_nodelay for inter-dc communication.
+# Disabling it will result in larger (but fewer) network packets being sent,
+# reducing overhead from the TCP protocol itself, at the cost of increasing
+# latency if you block for cross-datacenter responses.
+inter_dc_tcp_nodelay: false
+
+# TTL for different trace types used during logging of the repair process.
+tracetype_query_ttl: 86400
+tracetype_repair_ttl: 604800
+
+# If unset, all GC Pauses greater than gc_log_threshold_in_ms will log at
+# INFO level
+# UDFs (user defined functions) are disabled by default.
+# As of Cassandra 3.0 there is a sandbox in place that should prevent execution of evil code.
+enable_user_defined_functions: false
+
+# Enables scripted UDFs (JavaScript UDFs).
+# Java UDFs are always enabled, if enable_user_defined_functions is true.
+# Enable this option to be able to use UDFs with "language javascript" or any custom JSR-223 provider.
+# This option has no effect, if enable_user_defined_functions is false.
+enable_scripted_user_defined_functions: false
+
+# Enables materialized view creation on this node.
+# Materialized views are considered experimental and are not recommended for production use.
+enable_materialized_views: true
+
+# The default Windows kernel timer and scheduling resolution is 15.6ms for power conservation.
+# Lowering this value on Windows can provide much tighter latency and better throughput, however
+# some virtualized environments may see a negative performance impact from changing this setting
+# below their system default. The sysinternals 'clockres' tool can confirm your system's default
+# setting.
+windows_timer_interval: 1
+
+
+# Enables encrypting data at-rest (on disk). Different key providers can be plugged in, but the default reads from
+# a JCE-style keystore. A single keystore can hold multiple keys, but the one referenced by
+# the "key_alias" is the only key that will be used for encrypt opertaions; previously used keys
+# can still (and should!) be in the keystore and will be used on decrypt operations
+# (to handle the case of key rotation).
+#
+# It is strongly recommended to download and install Java Cryptography Extension (JCE)
+# Unlimited Strength Jurisdiction Policy Files for your version of the JDK.
+# (current link: http://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html)
+#
+# Currently, only the following file types are supported for transparent data encryption, although
+# more are coming in future cassandra releases: commitlog, hints
+transparent_data_encryption_options:
+    enabled: false
+    chunk_length_kb: 64
+    cipher: AES/CBC/PKCS5Padding
+    key_alias: testing:1
+    # CBC IV length for AES needs to be 16 bytes (which is also the default size)
+    # iv_length: 16
+    key_provider:
+      - class_name: org.apache.cassandra.security.JKSKeyProvider
+        parameters:
+          - keystore: conf/.keystore
+            keystore_password: cassandra
+            store_type: JCEKS
+            key_password: cassandra
+
+
+#####################
+# SAFETY THRESHOLDS #
+#####################
+
+# When executing a scan, within or across a partition, we need to keep the
+# tombstones seen in memory so we can return them to the coordinator, which
+# will use them to make sure other replicas also know about the deleted rows.
+# With workloads that generate a lot of tombstones, this can cause performance
+# problems and even exaust the server heap.
+# (http://www.datastax.com/dev/blog/cassandra-anti-patterns-queues-and-queue-like-datasets)
+# Adjust the thresholds here if you understand the dangers and want to
+# scan more tombstones anyway.  These thresholds may also be adjusted at runtime
+# using the StorageService mbean.
+tombstone_warn_threshold: 1000
+tombstone_failure_threshold: 100000
+
+# Log WARN on any multiple-partition batch size exceeding this value. 5kb per batch by default.
+# Caution should be taken on increasing the size of this threshold as it can lead to node instability.
+batch_size_warn_threshold_in_kb: 5
+
+# Fail any multiple-partition batch exceeding this value. 50kb (10x warn threshold) by default.
+batch_size_fail_threshold_in_kb: 50
+
+# Log WARN on any batches not of type LOGGED than span across more partitions than this limit
+unlogged_batch_across_partitions_warn_threshold: 10
+
+# Log a warning when compacting partitions larger than this value
+compaction_large_partition_warning_threshold_mb: 100
+
+# GC Pauses greater than 200 ms will be logged at INFO level
+# This threshold can be adjusted to minimize logging if necessary
+# gc_log_threshold_in_ms: 200
+
+# GC Pauses greater than gc_warn_threshold_in_ms will be logged at WARN level
+# Adjust the threshold based on your application throughput requirement. Setting to 0
+# will deactivate the feature.
+# gc_warn_threshold_in_ms: 1000
+
+# Maximum size of any value in SSTables. Safety measure to detect SSTable corruption
+# early. Any value size larger than this threshold will result into marking an SSTable
+# as corrupted. This should be positive and less than 2048.
+# max_value_size_in_mb: 256
+
+# Back-pressure settings #
+# If enabled, the coordinator will apply the back-pressure strategy specified below to each mutation
+# sent to replicas, with the aim of reducing pressure on overloaded replicas.
+back_pressure_enabled: false
+# The back-pressure strategy applied.
+# The default implementation, RateBasedBackPressure, takes three arguments:
+# high ratio, factor, and flow type, and uses the ratio between incoming mutation responses and outgoing mutation requests.
+# If below high ratio, outgoing mutations are rate limited according to the incoming rate decreased by the given factor;
+# if above high ratio, the rate limiting is increased by the given factor;
+# such factor is usually best configured between 1 and 10, use larger values for a faster recovery
+# at the expense of potentially more dropped mutations;
+# the rate limiting is applied according to the flow type: if FAST, it's rate limited at the speed of the fastest replica,
+# if SLOW at the speed of the slowest one.
+# New strategies can be added. Implementors need to implement org.apache.cassandra.net.BackpressureStrategy and
+# provide a public constructor accepting a Map<String, Object>.
+back_pressure_strategy:
+    - class_name: org.apache.cassandra.net.RateBasedBackPressure
+      parameters:
+        - high_ratio: 0.90
+          factor: 5
+          flow: FAST
+
+# Coalescing Strategies #
+# Coalescing multiples messages turns out to significantly boost message processing throughput (think doubling or more).
+# On bare metal, the floor for packet processing throughput is high enough that many applications won't notice, but in
+# virtualized environments, the point at which an application can be bound by network packet processing can be
+# surprisingly low compared to the throughput of task processing that is possible inside a VM. It's not that bare metal
+# doesn't benefit from coalescing messages, it's that the number of packets a bare metal network interface can process
+# is sufficient for many applications such that no load starvation is experienced even without coalescing.
+# There are other benefits to coalescing network messages that are harder to isolate with a simple metric like messages
+# per second. By coalescing multiple tasks together, a network thread can process multiple messages for the cost of one
+# trip to read from a socket, and all the task submission work can be done at the same time reducing context switching
+# and increasing cache friendliness of network message processing.
+# See CASSANDRA-8692 for details.
+
+# Strategy to use for coalescing messages in OutboundTcpConnection.
+# Can be fixed, movingaverage, timehorizon, disabled (default).
+# You can also specify a subclass of CoalescingStrategies.CoalescingStrategy by name.
+# otc_coalescing_strategy: DISABLED
+
+# How many microseconds to wait for coalescing. For fixed strategy this is the amount of time after the first
+# message is received before it will be sent with any accompanying messages. For moving average this is the
+# maximum amount of time that will be waited as well as the interval at which messages must arrive on average
+# for coalescing to be enabled.
+# otc_coalescing_window_us: 200
+
+# Do not try to coalesce messages if we already got that many messages. This should be more than 2 and less than 128.
+# otc_coalescing_enough_coalesced_messages: 8
+
+# How many milliseconds to wait between two expiration runs on the backlog (queue) of the OutboundTcpConnection.
+# Expiration is done if messages are piling up in the backlog. Droppable messages are expired to free the memory
+# taken by expired messages. The interval should be between 0 and 1000, and in most installations the default value
+# will be appropriate. A smaller value could potentially expire messages slightly sooner at the expense of more CPU
+# time and queue contention while iterating the backlog of messages.
+# An interval of 0 disables any wait time, which is the behavior of former Cassandra versions.
+#
+# otc_backlog_expiration_interval_ms: 200
+
+# Track a metric per keyspace indicating whether replication achieved the ideal consistency
+# level for writes without timing out. This is different from the consistency level requested by
+# each write which may be lower in order to facilitate availability.
+# ideal_consistency_level: EACH_QUORUM
+
+# Path to write full query log data to when the full query log is enabled
+# The full query log will recrusively delete the contents of this path at
+# times. Don't place links in this directory to other parts of the filesystem.
+#full_query_log_dir: /tmp/cassandrafullquerylog

--- a/stacks/dbrs/cassandra/conf/jvm-server.options-template
+++ b/stacks/dbrs/cassandra/conf/jvm-server.options-template
@@ -1,0 +1,194 @@
+###########################################################################
+#                         jvm-server.options                              #
+#                                                                         #
+# - all flags defined here will be used by cassandra to startup the JVM   #
+# - one flag should be specified per line                                 #
+# - lines that do not start with '-' will be ignored                      #
+# - only static flags are accepted (no variables or parameters)           #
+# - dynamic flags will be appended to these on cassandra-env              #
+#                                                                         #
+# See jvm8-server.options and jvm11-server.options for Java version       #
+# specific options.                                                       #
+###########################################################################
+
+######################
+# STARTUP PARAMETERS #
+######################
+
+# Uncomment any of the following properties to enable specific startup parameters
+
+# In a multi-instance deployment, multiple Cassandra instances will independently assume that all
+# CPU processors are available to it. This setting allows you to specify a smaller set of processors
+# and perhaps have affinity.
+#-Dcassandra.available_processors=number_of_processors
+
+# The directory location of the cassandra.yaml file.
+#-Dcassandra.config=directory
+
+# Sets the initial partitioner token for a node the first time the node is started.
+#-Dcassandra.initial_token=token
+
+# Set to false to start Cassandra on a node but not have the node join the cluster.
+#-Dcassandra.join_ring=true|false
+
+# Set to false to clear all gossip state for the node on restart. Use when you have changed node
+# information in cassandra.yaml (such as listen_address).
+#-Dcassandra.load_ring_state=true|false
+
+# Enable pluggable metrics reporter. See Pluggable metrics reporting in Cassandra 2.0.2.
+#-Dcassandra.metricsReporterConfigFile=file
+
+# Set the port on which the CQL native transport listens for clients. (Default: 9042)
+#-Dcassandra.native_transport_port=port
+
+# Overrides the partitioner. (Default: org.apache.cassandra.dht.Murmur3Partitioner)
+#-Dcassandra.partitioner=partitioner
+
+# To replace a node that has died, restart a new node in its place specifying the address of the
+# dead node. The new node must not have any data in its data directory, that is, it must be in the
+# same state as before bootstrapping.
+#-Dcassandra.replace_address=listen_address or broadcast_address of dead node
+
+# Allow restoring specific tables from an archived commit log.
+#-Dcassandra.replayList=table
+
+# Allows overriding of the default RING_DELAY (30000ms), which is the amount of time a node waits
+# before joining the ring.
+#-Dcassandra.ring_delay_ms=ms
+
+# Set the SSL port for encrypted communication. (Default: 7001)
+#-Dcassandra.ssl_storage_port=port
+
+# Set the port for inter-node communication. (Default: 7000)
+#-Dcassandra.storage_port=port
+
+# Set the default location for the trigger JARs. (Default: conf/triggers)
+#-Dcassandra.triggers_dir=directory
+
+# For testing new compaction and compression strategies. It allows you to experiment with different
+# strategies and benchmark write performance differences without affecting the production workload. 
+#-Dcassandra.write_survey=true
+
+# To disable configuration via JMX of auth caches (such as those for credentials, permissions and
+# roles). This will mean those config options can only be set (persistently) in cassandra.yaml
+# and will require a restart for new values to take effect.
+#-Dcassandra.disable_auth_caches_remote_configuration=true
+
+# To disable dynamic calculation of the page size used when indexing an entire partition (during
+# initial index build/rebuild). If set to true, the page size will be fixed to the default of
+# 10000 rows per page.
+#-Dcassandra.force_default_indexing_page_size=true
+
+# Imposes an upper bound on hint lifetime below the normal min gc_grace_seconds
+#-Dcassandra.maxHintTTL=max_hint_ttl_in_seconds
+
+#-Dpmem_path=
+#-Dpool_size=
+
+########################
+# GENERAL JVM SETTINGS #
+########################
+
+# enable assertions. highly suggested for correct application functionality.
+-ea
+
+# disable assertions for net.openhft.** because it runs out of memory by design
+# if enabled and run for more than just brief testing
+-da:net.openhft...
+
+# enable thread priorities, primarily so we can give periodic tasks
+# a lower priority to avoid interfering with client workload
+-XX:+UseThreadPriorities
+
+# Enable heap-dump if there's an OOM
+-XX:+HeapDumpOnOutOfMemoryError
+
+# Per-thread stack size.
+-Xss256k
+
+# Larger interned string table, for gossip's benefit (CASSANDRA-6410)
+-XX:StringTableSize=1000003
+
+# Make sure all memory is faulted and zeroed on startup.
+# This helps prevent soft faults in containers and makes
+# transparent hugepage allocation more effective.
+-XX:+AlwaysPreTouch
+
+# Disable biased locking as it does not benefit Cassandra.
+-XX:-UseBiasedLocking
+
+# Enable thread-local allocation blocks and allow the JVM to automatically
+# resize them at runtime.
+-XX:+UseTLAB
+-XX:+ResizeTLAB
+#-XX:+UseNUMA
+
+# http://www.evanjones.ca/jvm-mmap-pause.html
+-XX:+PerfDisableSharedMem
+
+# Prefer binding to IPv4 network intefaces (when net.ipv6.bindv6only=1). See
+# http://bugs.sun.com/bugdatabase/view_bug.do?bug_id=6342561 (short version:
+# comment out this entry to enable IPv6 support).
+-Djava.net.preferIPv4Stack=true
+
+### Debug options
+
+# uncomment to enable flight recorder
+#-XX:+UnlockCommercialFeatures
+#-XX:+FlightRecorder
+
+# uncomment to have Cassandra JVM listen for remote debuggers/profilers on port 1414
+#-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=1414
+
+# uncomment to have Cassandra JVM log internal method compilation (developers only)
+#-XX:+UnlockDiagnosticVMOptions
+#-XX:+LogCompilation
+
+#################
+# HEAP SETTINGS #
+#################
+
+# Heap size is automatically calculated by cassandra-env based on this
+# formula: max(min(1/2 ram, 1024MB), min(1/4 ram, 8GB))
+# That is:
+# - calculate 1/2 ram and cap to 1024MB
+# - calculate 1/4 ram and cap to 8192MB
+# - pick the max
+#
+# For production use you may wish to adjust this for your environment.
+# If that's the case, uncomment the -Xmx and Xms options below to override the
+# automatic calculation of JVM heap memory.
+#
+# It is recommended to set min (-Xms) and max (-Xmx) heap sizes to
+# the same value to avoid stop-the-world GC pauses during resize, and
+# so that we can lock the heap in memory on startup to prevent any
+# of it from being swapped out.
+#-Xms4G
+#-Xmx4G
+
+# Young generation size is automatically calculated by cassandra-env
+# based on this formula: min(100 * num_cores, 1/4 * heap size)
+#
+# The main trade-off for the young generation is that the larger it
+# is, the longer GC pause times will be. The shorter it is, the more
+# expensive GC will be (usually).
+#
+# It is not recommended to set the young generation size if using the
+# G1 GC, since that will override the target pause-time goal.
+# More info: http://www.oracle.com/technetwork/articles/java/g1gc-1984535.html
+#
+# The example below assumes a modern 8-core+ machine for decent
+# times. If in doubt, and if you do not particularly want to tweak, go
+# 100 MB per physical CPU core.
+#-Xmn800M
+
+###################################
+# EXPIRATION DATE OVERFLOW POLICY #
+###################################
+
+# Defines how to handle INSERT requests with TTL exceeding the maximum supported expiration date:
+# * REJECT: this is the default policy and will reject any requests with expiration date timestamp after 2038-01-19T03:14:06+00:00.
+# * CAP: any insert with TTL expiring after 2038-01-19T03:14:06+00:00 will expire on 2038-01-19T03:14:06+00:00 and the client will receive a warning.
+# * CAP_NOWARN: same as previous, except that the client warning will not be emitted.
+#
+#-Dcassandra.expiration_date_overflow_policy=REJECT

--- a/stacks/dbrs/cassandra/conf/jvm11-server.options
+++ b/stacks/dbrs/cassandra/conf/jvm11-server.options
@@ -1,0 +1,96 @@
+###########################################################################
+#                         jvm11-server.options                            #
+#                                                                         #
+# See jvm-server.options. This file is specific for Java 11 and newer.    #
+###########################################################################
+
+#################
+#  GC SETTINGS  #
+#################
+
+
+
+### CMS Settings
+#-XX:+UseConcMarkSweepGC
+#-XX:+CMSParallelRemarkEnabled
+#-XX:SurvivorRatio=8
+#-XX:MaxTenuringThreshold=1
+#-XX:CMSInitiatingOccupancyFraction=75
+#-XX:+UseCMSInitiatingOccupancyOnly
+#-XX:CMSWaitDuration=10000
+#-XX:+CMSParallelInitialMarkEnabled
+#-XX:+CMSEdenChunksRecordAlways
+### some JVMs will fill up their heap when accessed via JMX, see CASSANDRA-6541
+#-XX:+CMSClassUnloadingEnabled
+-XX:+UseAdaptiveSizePolicy
+
+
+### G1 Settings
+## Use the Hotspot garbage-first collector.
+#-XX:+UseG1GC
+#-XX:+ParallelRefProcEnabled
+
+#
+## Have the JVM do less remembered set work during STW, instead
+## preferring concurrent GC. Reduces p99.9 latency.
+#-XX:G1RSetUpdatingPauseTimePercent=5
+#
+## Main G1GC tunable: lowering the pause target will lower throughput and vise versa.
+## 200ms is the JVM default and lowest viable setting
+## 1000ms increases throughput. Keep it smaller than the timeouts in cassandra.yaml.
+#-XX:MaxGCPauseMillis=500
+
+## Optional G1 Settings
+# Save CPU time on large (>= 16GB) heaps by delaying region scanning
+# until the heap is 70% full. The default in Hotspot 8u40 is 40%.
+#-XX:InitiatingHeapOccupancyPercent=70
+
+# For systems with > 8 cores, the default ParallelGCThreads is 5/8 the number of logical cores.
+# Otherwise equal to the number of cores when 8 or less.
+# Machines with > 10 cores should try setting these to <= full cores.
+#-XX:ParallelGCThreads=16
+# By default, ConcGCThreads is 1/4 of ParallelGCThreads.
+# Setting both to the same value can reduce STW durations.
+#-XX:ConcGCThreads=16
+
+
+### JPMS
+
+-Djdk.attach.allowAttachSelf=true
+--add-exports java.base/jdk.internal.misc=ALL-UNNAMED
+--add-exports java.base/jdk.internal.ref=ALL-UNNAMED
+--add-exports java.base/sun.nio.ch=ALL-UNNAMED
+--add-exports java.management.rmi/com.sun.jmx.remote.internal.rmi=ALL-UNNAMED
+--add-exports java.rmi/sun.rmi.registry=ALL-UNNAMED
+--add-exports java.rmi/sun.rmi.server=ALL-UNNAMED
+--add-exports java.sql/java.sql=ALL-UNNAMED
+
+--add-opens java.base/java.lang.module=ALL-UNNAMED
+--add-opens java.base/jdk.internal.loader=ALL-UNNAMED
+--add-opens java.base/jdk.internal.ref=ALL-UNNAMED
+--add-opens java.base/jdk.internal.reflect=ALL-UNNAMED
+--add-opens java.base/jdk.internal.math=ALL-UNNAMED
+--add-opens java.base/jdk.internal.module=ALL-UNNAMED
+--add-opens java.base/jdk.internal.util.jar=ALL-UNNAMED
+--add-opens jdk.management/com.sun.management.internal=ALL-UNNAMED
+
+
+### GC logging options -- uncomment to enable
+
+# Java 11 (and newer) GC logging options:
+# See description of https://bugs.openjdk.java.net/browse/JDK-8046148 for details about the syntax
+# The following is the equivalent to -XX:+PrintGCDetails -XX:+UseGCLogFileRotation -XX:NumberOfGCLogFiles=10 -XX:GCLogFileSize=10M
+#-Xlog:gc=info,heap*=trace,age*=debug,safepoint=info,promotion*=trace:file=/var/log/cassandra/gc.log:time,uptime,pid,tid,level:filecount=10,filesize=10485760
+
+# Notes for Java 8 migration:
+#
+# -XX:+PrintGCDetails                   maps to -Xlog:gc*:... - i.e. add a '*' after "gc"
+# -XX:+PrintGCDateStamps                maps to decorator 'time'
+#
+# -XX:+PrintHeapAtGC                    maps to 'heap' with level 'trace'
+# -XX:+PrintTenuringDistribution        maps to 'age' with level 'debug'
+# -XX:+PrintGCApplicationStoppedTime    maps to 'safepoint' with level 'info'
+# -XX:+PrintPromotionFailure            maps to 'promotion' with level 'trace'
+# -XX:PrintFLSStatistics=1              maps to 'freelist' with level 'trace'
+
+# The newline in the end of file is intentional

--- a/stacks/dbrs/cassandra/conf/jvm8-server.options
+++ b/stacks/dbrs/cassandra/conf/jvm8-server.options
@@ -1,0 +1,77 @@
+###########################################################################
+#                          jvm8-server.options                            #
+#                                                                         #
+# See jvm-server.options. This file is specific for Java 8 and newer.     #
+###########################################################################
+
+########################
+# GENERAL JVM SETTINGS #
+########################
+
+# allows lowering thread priority without being root on linux - probably
+# not necessary on Windows but doesn't harm anything.
+# see http://tech.stolsvik.com/2010/01/linux-java-thread-priorities-workaround.html
+-XX:ThreadPriorityPolicy=42
+
+#################
+#  GC SETTINGS  #
+#################
+
+### CMS Settings
+#-XX:+UseParNewGC
+#-XX:+UseConcMarkSweepGC
+#-XX:+CMSParallelRemarkEnabled
+#-XX:SurvivorRatio=8
+#-XX:MaxTenuringThreshold=1
+#-XX:CMSInitiatingOccupancyFraction=75
+#-XX:+UseCMSInitiatingOccupancyOnly
+#-XX:CMSWaitDuration=10000
+#-XX:+CMSParallelInitialMarkEnabled
+#-XX:+CMSEdenChunksRecordAlways
+## some JVMs will fill up their heap when accessed via JMX, see CASSANDRA-6541
+#-XX:+CMSClassUnloadingEnabled
+-XX:+UseAdaptiveSizePolicy
+
+### G1 Settings
+## Use the Hotspot garbage-first collector.
+#-XX:+UseG1GC
+#-XX:+ParallelRefProcEnabled
+
+#
+## Have the JVM do less remembered set work during STW, instead
+## preferring concurrent GC. Reduces p99.9 latency.
+#-XX:G1RSetUpdatingPauseTimePercent=5
+#
+## Main G1GC tunable: lowering the pause target will lower throughput and vise versa.
+## 200ms is the JVM default and lowest viable setting
+## 1000ms increases throughput. Keep it smaller than the timeouts in cassandra.yaml.
+#-XX:MaxGCPauseMillis=500
+
+## Optional G1 Settings
+# Save CPU time on large (>= 16GB) heaps by delaying region scanning
+# until the heap is 70% full. The default in Hotspot 8u40 is 40%.
+#-XX:InitiatingHeapOccupancyPercent=70
+
+# For systems with > 8 cores, the default ParallelGCThreads is 5/8 the number of logical cores.
+# Otherwise equal to the number of cores when 8 or less.
+# Machines with > 10 cores should try setting these to <= full cores.
+#-XX:ParallelGCThreads=16
+# By default, ConcGCThreads is 1/4 of ParallelGCThreads.
+# Setting both to the same value can reduce STW durations.
+#-XX:ConcGCThreads=16
+
+### GC logging options -- uncomment to enable
+
+-XX:+PrintGCDetails
+-XX:+PrintGCDateStamps
+-XX:+PrintHeapAtGC
+-XX:+PrintTenuringDistribution
+-XX:+PrintGCApplicationStoppedTime
+-XX:+PrintPromotionFailure
+#-XX:PrintFLSStatistics=1
+#-Xloggc:/var/log/cassandra/gc.log
+-XX:+UseGCLogFileRotation
+-XX:NumberOfGCLogFiles=10
+-XX:GCLogFileSize=10M
+
+# The newline in the end of file is intentional

--- a/stacks/dbrs/cassandra/licenses/README.md
+++ b/stacks/dbrs/cassandra/licenses/README.md
@@ -1,0 +1,8 @@
+## Additional details on licenses
+
+As with all Docker images, these likely also contain other software which may
+be under other licenses (such as Bash, etc from the base distribution, along
+with any direct or indirect dependencies of the primary software being
+contained). As for any pre-built image usage, it is the image user's
+responsibility to ensure that any use of this image complies with any relevant
+licenses for all software contained within.

--- a/stacks/dbrs/cassandra/licenses/cassandra_LICENSE
+++ b/stacks/dbrs/cassandra/licenses/cassandra_LICENSE
@@ -1,0 +1,209 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+
+THIRD-PARTY DEPENDENCIES
+========================
+Convenience copies of some third-party dependencies are distributed with
+Apache Cassandra as Java jar files in lib/. Licensing information for
+these files can be found in the lib/licenses directory.

--- a/stacks/dbrs/cassandra/licenses/clear_LICENSE
+++ b/stacks/dbrs/cassandra/licenses/clear_LICENSE
@@ -1,0 +1,147 @@
+
+List of licenses used in Clear Linux OS.
+
+This list is automatically generated. If you spot a mistake or
+omission, please mention this on dev@lists.clearlinux.org.
+
+To read the full license text for these licenses, please visit
+http://spdx.org/licenses/. A few licenses in this list are not
+declared on the http://spdx.org/licenses/ website, they are listed
+at the bottom of this list.
+
+AFL-2.0
+AFL-2.1
+AGPL-3.0
+AML
+APSL-2.0
+Apache-1.1
+Apache-2.0
+Artistic-1.0
+Artistic-1.0-Perl
+Artistic-2.0
+BSD-2-Clause
+BSD-2-Clause-FreeBSD
+BSD-2-Clause-NetBSD
+BSD-3-Clause
+BSD-3-Clause-Attribution
+BSD-3-Clause-Clear
+BSD-3-Clause-LBNL
+BSD-4-Clause
+BSD-4-Clause-UC
+BSL-1.0
+CC-BY-2.0
+CC-BY-3.0
+CC-BY-4.0
+CC-BY-ND-4.0
+CC-BY-SA-2.0
+CC-BY-SA-3.0
+CC-BY-SA-4.0
+CC0-1.0
+CDDL-1.0
+CDDL-1.1
+CECILL-1.1
+CPL-1.0
+ClArtistic
+Distributable
+EPL-1.0
+FSFULLR
+FTL
+GFDL-1.1
+GFDL-1.2
+GFDL-1.3
+GFDL-1.3+
+GL2PS
+GPL-1.0
+GPL-1.0+
+GPL-2.0
+GPL-2.0+
+GPL-2.0-only
+GPL-2.0-or-later
+GPL-3.0
+GPL-3.0+
+GPL-3.0-only
+HPND
+ICU
+IJG
+ISC
+ImageMagick
+Imlib2
+Intel
+JSON
+JasPer-2.0
+LAL-1.2
+LGPL-2.0
+LGPL-2.0+
+LGPL-2.1
+LGPL-2.1+
+LGPL-2.1-only
+LGPL-3.0
+LGPL-3.0+
+LPPL-1.0
+LPPL-1.3c
+Libpng
+MIT
+MIT-Opengroup
+MIT-enna
+MIT-feh
+MPL-1.1
+MPL-2.0
+MPL-2.0-no-copyleft-exception
+MS-PL
+MTLL
+MakeIndex
+NCSA
+NTP
+NetCDF
+Nunit
+OFL-1.0
+OFL-1.1
+OLDAP-2.0.1
+OLDAP-2.8
+OML
+OSL-2.0
+OpenSSL
+PHP-3.01
+PostgreSQL
+Public-Domain
+Python-2.0
+QPL-1.0
+Qhull
+Rdisc
+Ruby
+SAX-PD
+SGI-B-1.0
+SGI-B-1.1
+SGI-B-2.0
+SISSL
+Saxpath
+Sleepycat
+TCL
+Unicode-TOU
+Unlicense
+Vim
+W3C
+W3C-19980720
+WTFPL
+X11
+ZPL-2.0
+ZPL-2.1
+Zend-2.0
+Zlib
+bzip2-1.0.5
+bzip2-1.0.6
+gnuplot
+libtiff
+psutils
+zlib-acknowledgement
+
+The following licenses are not standard spdx identifiers:
+- Copyright
+- Distributable
+- Public-Domain
+
+These are used for projects that have explicitly granted redistribution
+of the project source code, but don't have a typical OSI approved
+license identifier.
+
+

--- a/stacks/dbrs/cassandra/scripts/build-cassandra-pmem.sh
+++ b/stacks/dbrs/cassandra/scripts/build-cassandra-pmem.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+#Script for building cassandra with pmem support on Clear Linux
+#Bundle dependencies: c-basic java-basic devpkg-pmdk pmdk
+#
+#All the repositories are built on CASSANDRA_BUILD_DIR and a tar.gz file is generated
+#on the folder you run this script
+export JAVA_HOME='/usr/lib/jvm/java-1.8.0-openjdk'
+
+INITIAL_DIR=$(pwd)
+CASSANDRA_BUILD_DIR='/tmp/cassandra-build'
+LLPL_REPO='https://github.com/pmem/llpl.git'
+CASSANDRA_PMEM_REPO='https://github.com/intel/cassandra-pmem'
+CASSANDRA_PMEM_BRANCH='13981_llpl_engine'
+
+if [ -d $CASSANDRA_BUILD_DIR ] 
+then
+	rm -rf $CASSANDRA_BUILD_DIR/*
+else
+	mkdir $CASSANDRA_BUILD_DIR
+fi
+
+#Build LLPL
+cd $CASSANDRA_BUILD_DIR
+git clone $LLPL_REPO && \
+cd $CASSANDRA_BUILD_DIR/llpl && \
+make && \
+cd $CASSANDRA_BUILD_DIR/llpl/target/classes && \
+jar cvf llpl.jar lib/
+
+
+#Build Cassandra PMEM
+cd $CASSANDRA_BUILD_DIR && \
+git clone -b $CASSANDRA_PMEM_BRANCH --single-branch  $CASSANDRA_PMEM_REPO && \
+cd $CASSANDRA_BUILD_DIR/cassandra-pmem && \
+cp $CASSANDRA_BUILD_DIR/llpl/target/classes/llpl.jar $CASSANDRA_BUILD_DIR/cassandra-pmem/lib/ && \
+cp $CASSANDRA_BUILD_DIR/llpl/target/cppbuild/libllpl.so $CASSANDRA_BUILD_DIR/cassandra-pmem/lib/sigar-bin/ && \
+ant -autoproxy && \
+cd $CASSANDRA_BUILD_DIR && \
+mv cassandra-pmem cassandra
+tar -zcvf cassandra-pmem-build.tar.gz cassandra
+mv cassandra-pmem-build.tar.gz $INITIAL_DIR
+cd $INITIAL_DIR

--- a/stacks/dbrs/cassandra/scripts/change_devdax_perms.sh
+++ b/stacks/dbrs/cassandra/scripts/change_devdax_perms.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+/usr/bin/chown cassandra-user /dev/dax0.0

--- a/stacks/dbrs/cassandra/scripts/change_fsdax_perms.sh
+++ b/stacks/dbrs/cassandra/scripts/change_fsdax_perms.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+/usr/bin/chown cassandra-user -R /mnt/pmem
+/usr/bin/chmod a+rw -R /mnt/pmem

--- a/stacks/dbrs/cassandra/scripts/change_persistent_dirs_perms.sh
+++ b/stacks/dbrs/cassandra/scripts/change_persistent_dirs_perms.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+DATA_DIR="/workspace/cassandra/data"
+LOG_DIR="/workspace/cassandra/logs"
+
+/usr/bin/chown cassandra-user -R $DATA_DIR
+/usr/bin/chown cassandra-user -R $LOG_DIR

--- a/stacks/dbrs/cassandra/scripts/docker-entrypoint.sh
+++ b/stacks/dbrs/cassandra/scripts/docker-entrypoint.sh
@@ -1,0 +1,109 @@
+#!/bin/bash
+set -x
+
+#Work in a copy
+ORIG_CONFIG_FILE="/workspace/cassandra/conf/cassandra.yaml"
+CONFIG_FILE="/workspace/cassandra/conf/cassandra-template.yaml"
+ORIG_JVM_OPTIONS_FILE="/workspace/cassandra/conf/jvm-server.options"
+JVM_OPTIONS_FILE="/workspace/cassandra/conf/jvm-server.options-template"
+SUDOERS_FILE="/etc/sudoers.d/cassandra-user"
+
+function grant_persistent_dirs_permissions {
+        sudo /usr/local/bin/change_persistent_dirs_perms.sh
+}
+
+function grant_pmem_permissions {
+	if [ -d /mnt/pmem ]
+	then
+		sudo /usr/local/bin/change_fsdax_perms.sh
+	elif [ -e /dev/dax0.0 ]
+	then
+		sudo /usr/local/bin/change_devdax_perms.sh
+	else
+		echo "No pmem devices are attached to the container on /mnt/pmem(fsdax) or /dev/dax(devdax)!"
+                exit 1
+        fi
+}
+
+function create_jvm_options {
+	#function to create jvm-server.options file at runtime
+	echo "Generating jvm-server.options file"
+        #Determining if the image is going to use devdax or fsdax devices for pmem
+        if [ -d /mnt/pmem ]
+	then
+                CASSANDRA_FSDAX_POOL_SIZE_GB=${CASSANDRA_FSDAX_POOL_SIZE_GB:-'1'}
+	        CASSANDRA_PMEM_POOL_NAME=${CASSANDRA_PMEM_POOL_NAME:-'cassandra_pool'}
+	        echo -e "-Dpmem_path=/mnt/pmem/$CASSANDRA_PMEM_POOL_NAME\n-Dpool_size=$(echo $(( $CASSANDRA_FSDAX_POOL_SIZE_GB * 1073741824 )) )" | tee -a $JVM_OPTIONS_FILE
+        elif [ -e /dev/dax0.0 ]
+        then
+                echo -e "-Dpmem_path=/dev/dax0.0\n-Dpool_size=0" | tee -a $JVM_OPTIONS_FILE
+        else
+	        echo "No pmem devices are attached to the container!"
+	        exit 1
+        fi
+
+        #Copy generated config file to the default location
+        echo "Copying generated jvm-server.options template to default config location..."
+        cp $JVM_OPTIONS_FILE $ORIG_JVM_OPTIONS_FILE
+}
+
+function create_cassandra_yaml {
+	#Function to create cassandra.yaml file at runtime
+	echo "Generating cassandra.yaml file"
+        #Get container IP Address on the first interface
+        echo "Getting container primary IP address..."
+        CONTAINER_IP=$(ip address | grep inet | egrep -v "inet6|127.0.0.1" | awk '{print $2}' | awk -F "/" '{print $1}' | head -1)
+        echo "The container IP address is: $CONTAINER_IP"
+
+        #Cluster name
+        CASSANDRA_CLUSTER_NAME=${CASSANDRA_CLUSTER_NAME:-'Cassandra Cluster'}
+        echo "cluster_name: '$CASSANDRA_CLUSTER_NAME'" | tee -a $CONFIG_FILE
+
+        #Listen address
+        CASSANDRA_LISTEN_ADDRESS=${CASSANDRA_LISTEN_ADDRESS:-$CONTAINER_IP}
+        echo "listen_address: '$CASSANDRA_LISTEN_ADDRESS'" | tee -a $CONFIG_FILE
+
+        #Seed addresses
+        CASSANDRA_SEED_ADDRESSES=${CASSANDRA_SEED_ADDRESSES:-"$CASSANDRA_LISTEN_ADDRESS:7000"}
+        echo -e "seed_provider:\n  - class_name: org.apache.cassandra.locator.SimpleSeedProvider\n    parameters:\n        - seeds: '$CASSANDRA_SEED_ADDRESSES'" | tee -a $CONFIG_FILE
+
+        #Snitch
+        CASSANDRA_SNITCH=${CASSANDRA_SNITCH:-'SimpleSnitch'} 
+        echo "endpoint_snitch: $CASSANDRA_SNITCH" | tee -a $CONFIG_FILE
+
+        #RPC listen addresss
+        CASSANDRA_RPC_ADDRESS=${CASSANDRA_RPC_ADDRESS:-$CONTAINER_IP}
+        echo "rpc_address: $CASSANDRA_RPC_ADDRESS" | tee -a $CONFIG_FILE
+
+        #Copy generated config file to the default location
+        echo "Copying generated cassandra.yaml template to default config location..."
+        cp $CONFIG_FILE $ORIG_CONFIG_FILE
+}
+
+grant_persistent_dirs_permissions
+grant_pmem_permissions
+
+#Creating jvm-server.options if none provided
+if [ ! -f $ORIG_JVM_OPTIONS_FILE ]
+then
+	create_jvm_options
+else
+	echo "Using mounted jvm-server.options file..."
+fi
+#creating cassandra.yaml if none provided
+if [ ! -f $ORIG_CONFIG_FILE ]
+then
+        create_cassandra_yaml
+else
+	echo "Using mounted cassandra.yaml file..."
+fi
+
+echo "Starting Cassandra..."
+
+# first arg is `-f` or `--some-option`
+# or there are no args
+if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
+	set -- /workspace/cassandra/bin/cassandra "$@"
+fi
+
+exec "$@"

--- a/stacks/dbrs/cassandra/scripts/docker-healthcheck
+++ b/stacks/dbrs/cassandra/scripts/docker-healthcheck
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -eo pipefail
+
+host="$(hostname --ip-address || echo '127.0.0.1')"
+port="$(cat /workspace/cassandra/conf/cassandra.yaml | grep 'native_transport_port:' | tail -1 | awk '{print $2}' || echo '9042' )"
+
+if /workspace/cassandra/bin/cqlsh "$host" "$port" < /dev/null; then
+	exit 0
+fi
+
+exit 1

--- a/stacks/dbrs/redis/Dockerfile
+++ b/stacks/dbrs/redis/Dockerfile
@@ -1,0 +1,28 @@
+FROM clearlinux AS build-redis
+MAINTAINER otc-swstacks@intel.com
+
+RUN swupd bundle-add --quiet --no-progress git c-basic devpkg-ndctl os-testsuite-phoronix-server
+
+RUN  useradd redis-user
+
+ENV REDIS_PMEMD="/tmp/redis"
+ENV EXTRA_CFLAGS=" -Wno-error"
+RUN  git clone https://github.com/pmem/pmem-redis $REDIS_PMEMD && \
+     cd $REDIS_PMEMD && \
+     git submodule init && git submodule update && \
+     make USE_NVM=yes install
+
+FROM clearlinux/os-core:latest
+
+RUN useradd redis-user
+
+COPY scripts/docker-entrypoint.sh scripts/docker-healthcheck /usr/bin/
+COPY --from=build-redis /usr/bin/ps /usr/bin/
+COPY --from=build-redis /usr/local/bin/* /usr/bin/
+COPY --from=build-redis /usr/lib64/libnuma.so* /usr/lib64/libprocps.so* /usr/lib64/
+
+HEALTHCHECK --interval=15s CMD ["docker-healthcheck"]
+
+ENTRYPOINT ["docker-entrypoint.sh"]
+USER redis-user
+CMD echo "USE: redis-server --nvm-maxcapacity <size> --nvm-dir <persistent mount point> --nvm-threshold <threshold to move to PMEM>" && redis-server --help

--- a/stacks/dbrs/redis/README.md
+++ b/stacks/dbrs/redis/README.md
@@ -1,0 +1,76 @@
+## Database Reference Stack with Redis
+
+[![](https://images.microbadger.com/badges/image/clearlinux/stacks-dbrs-redis.svg)](http://microbadger.com/images/clearlinux/stacks-dbrs-redis "Get your own image badge on microbadger.com")
+
+### Building Locally
+
+The Dockerfiles for all Clear Linux* OS based container images are available at [dockerfiles repository](https://github.com/clearlinux/dockerfiles). These can be used to build and modify the container images.
+
+1. Clone the clearlinux/dockerfiles repository.
+
+    ```bash
+    git clone https://github.com/clearlinux/dockerfiles.git
+    ```
+
+2. Change to the directory of the application:
+
+    ```bash
+    cd dockerfiles/stacks/dbrs/redis
+    ```
+
+3. Build the container image. Default build args in Docker are on: https://docs.docker.com/engine/reference/builder/#arg
+
+    ```bash
+    docker build --no-cache -t clearlinux/stacks-dbrs-redis .
+    ```
+
+### Clone the repository
+
+
+
+### Run DBRS Redis as a standalone container
+
+Prior to start the application, you will need to have the DCPMM in fsdax mode with a file system and mounted in `/mnt/dax0`. To know how to configure, read the [DBRS guide](https://docs.01.org/clearlinux/latest/guides/stacks/dbrs.html)
+
+To start the application
+
+```bash
+docker run --mount type=bind,source=/mnt/dax0,target=/mnt/pmem0 -i -d --name pmem-redis ${DOCKER_IMAGE} --nvm-maxcapacity 200 --nvm-dir /mnt/pmem0 --nvm-threshold 64 --protected-mode no
+```
+
+### Deploy DBRS Redis cluster on Kubernetes
+
+#### Kubernetes installation
+
+To install Kubernetes in Clear Linux, follow the instructions in the Clear Linux's [Kubernetes Tutorial](https://docs.01.org/clearlinux/latest/tutorials/kubernetes.html)
+
+After setting up Kubernetes, you will need to enable it to support DCPMM suing the pmem-csi driver. To install the driver follow the instructions in the [pmem-csi repository](https://github.com/intel/pmem-csi) file.
+
+#### Redis operator install
+
+The source code of the redis operator can be found in this [repository](https://github.com/spotahome/redis-operator).
+
+To install the operator, go to you kubernetes control plane and execute the following command:
+
+```bash
+kubectl create -f https://raw.githubusercontent.com/spotahome/redis-operator/master/example/operator/all-redis-operator-resources.yaml
+```
+
+#### Redis operator usage
+
+After installing the operator you are ready to deploy redisfailover instances using a yaml file, there is an example for persistent memory [here](https://github.com/spotahome/redis-operator/blob/master/example/redisfailover/pmem.yaml). You can download it and change the source of the image to clearlinux/stacks-dbrs-redis. We have created our own yaml based on this example, you can find it in this repo with the name: `redis-failover.yml`
+
+In the `redis-failover.yml` there is a placeholder for the image name, substitute the word `PMEM_REDIS_IMAGE` with the name of the clearlinux/stacks-dbrs-redis image.
+
+To start a redisfailover instance in Kubernetes using our yaml, move the file to the kubernetes server, then run:
+
+```bash
+kubectl create -f redis-failover.yml
+```
+
+##### Known issues
+
+There is an issue of the sentinels not having enough memory to create the InitContainer. The issue has been reported [here](https://github.com/spotahome/redis-operator/issues/176). The current workaround is to build the image increasing the limits for the InitContainer memory to 32Mb
+
+**Note**
+If you already have a redis-operator, you will need to delete it before installing a new one.

--- a/stacks/dbrs/redis/licenses/README.md
+++ b/stacks/dbrs/redis/licenses/README.md
@@ -1,0 +1,8 @@
+## Additional details on licenses
+
+As with all Docker images, these likely also contain other software which may
+be under other licenses (such as Bash, etc from the base distribution, along
+with any direct or indirect dependencies of the primary software being
+contained). As for any pre-built image usage, it is the image user's
+responsibility to ensure that any use of this image complies with any relevant
+licenses for all software contained within.

--- a/stacks/dbrs/redis/licenses/clear_LICENSE
+++ b/stacks/dbrs/redis/licenses/clear_LICENSE
@@ -1,0 +1,147 @@
+
+List of licenses used in Clear Linux OS.
+
+This list is automatically generated. If you spot a mistake or
+omission, please mention this on dev@lists.clearlinux.org.
+
+To read the full license text for these licenses, please visit
+http://spdx.org/licenses/. A few licenses in this list are not
+declared on the http://spdx.org/licenses/ website, they are listed
+at the bottom of this list.
+
+AFL-2.0
+AFL-2.1
+AGPL-3.0
+AML
+APSL-2.0
+Apache-1.1
+Apache-2.0
+Artistic-1.0
+Artistic-1.0-Perl
+Artistic-2.0
+BSD-2-Clause
+BSD-2-Clause-FreeBSD
+BSD-2-Clause-NetBSD
+BSD-3-Clause
+BSD-3-Clause-Attribution
+BSD-3-Clause-Clear
+BSD-3-Clause-LBNL
+BSD-4-Clause
+BSD-4-Clause-UC
+BSL-1.0
+CC-BY-2.0
+CC-BY-3.0
+CC-BY-4.0
+CC-BY-ND-4.0
+CC-BY-SA-2.0
+CC-BY-SA-3.0
+CC-BY-SA-4.0
+CC0-1.0
+CDDL-1.0
+CDDL-1.1
+CECILL-1.1
+CPL-1.0
+ClArtistic
+Distributable
+EPL-1.0
+FSFULLR
+FTL
+GFDL-1.1
+GFDL-1.2
+GFDL-1.3
+GFDL-1.3+
+GL2PS
+GPL-1.0
+GPL-1.0+
+GPL-2.0
+GPL-2.0+
+GPL-2.0-only
+GPL-2.0-or-later
+GPL-3.0
+GPL-3.0+
+GPL-3.0-only
+HPND
+ICU
+IJG
+ISC
+ImageMagick
+Imlib2
+Intel
+JSON
+JasPer-2.0
+LAL-1.2
+LGPL-2.0
+LGPL-2.0+
+LGPL-2.1
+LGPL-2.1+
+LGPL-2.1-only
+LGPL-3.0
+LGPL-3.0+
+LPPL-1.0
+LPPL-1.3c
+Libpng
+MIT
+MIT-Opengroup
+MIT-enna
+MIT-feh
+MPL-1.1
+MPL-2.0
+MPL-2.0-no-copyleft-exception
+MS-PL
+MTLL
+MakeIndex
+NCSA
+NTP
+NetCDF
+Nunit
+OFL-1.0
+OFL-1.1
+OLDAP-2.0.1
+OLDAP-2.8
+OML
+OSL-2.0
+OpenSSL
+PHP-3.01
+PostgreSQL
+Public-Domain
+Python-2.0
+QPL-1.0
+Qhull
+Rdisc
+Ruby
+SAX-PD
+SGI-B-1.0
+SGI-B-1.1
+SGI-B-2.0
+SISSL
+Saxpath
+Sleepycat
+TCL
+Unicode-TOU
+Unlicense
+Vim
+W3C
+W3C-19980720
+WTFPL
+X11
+ZPL-2.0
+ZPL-2.1
+Zend-2.0
+Zlib
+bzip2-1.0.5
+bzip2-1.0.6
+gnuplot
+libtiff
+psutils
+zlib-acknowledgement
+
+The following licenses are not standard spdx identifiers:
+- Copyright
+- Distributable
+- Public-Domain
+
+These are used for projects that have explicitly granted redistribution
+of the project source code, but don't have a typical OSI approved
+license identifier.
+
+

--- a/stacks/dbrs/redis/licenses/redis_LICENSE
+++ b/stacks/dbrs/redis/licenses/redis_LICENSE
@@ -1,0 +1,10 @@
+Copyright (c) 2006-2015, Salvatore Sanfilippo
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+    * Neither the name of Redis nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/stacks/dbrs/redis/redis-failover.yml
+++ b/stacks/dbrs/redis/redis-failover.yml
@@ -1,0 +1,44 @@
+apiVersion: databases.spotahome.com/v1
+kind: RedisFailover
+metadata:
+  name: redisfailover-pmem
+spec:
+  sentinel:
+    replicas: 3
+    command:
+      - "redis-server"
+      - "/redis/sentinel.conf"
+      - "--sentinel"
+      - "--protected-mode"
+      - "no"
+  redis:
+    securityContext:
+      runAsUser: 1000
+      runAsGroup: 1000
+      fsGroup: 1000
+    replicas: 3
+    image: PMEM_REDIS_IMAGE
+    command:
+      - "redis-server"
+      - "/redis/redis.conf"
+      - "--nvm-maxcapacity"
+      - "200"
+      - "--nvm-dir"
+      - "/data"
+      - "--nvm-threshold"
+      - "44"
+      - "--protected-mode"
+      - "no"
+      - "--dir"
+      - "/tmp"
+    storage:
+      persistentVolumeClaim:
+        metadata:
+          name: redisfailover-pmem-data
+        spec:
+          accessModes:
+            - ReadWriteOnce
+          resources:
+            requests:
+              storage: 100Mi
+          storageClassName: pmem-csi-sc-ext4

--- a/stacks/dbrs/redis/scripts/docker-entrypoint.sh
+++ b/stacks/dbrs/redis/scripts/docker-entrypoint.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+set -x
+
+if [ -d /mnt/pmem0 ]
+then
+        chown redis-user -R /mnt/pmem0/
+        chmod -R a+rw /mnt/pmem0
+else
+        echo "No pmem devices (fsdax) are attached to the container on /mnt/pmem0"
+        exit 1
+fi
+
+if [ "${1#-}" != "$1" ] || [ "${1%.conf}" != "$1" ]; then
+        set -- redis-server "$@"
+fi
+
+exec "$@"

--- a/stacks/dbrs/redis/scripts/docker-healthcheck
+++ b/stacks/dbrs/redis/scripts/docker-healthcheck
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+srv=$(ps -C redis-server -o pid=)
+cli=$(ps -C redis-cli -o pid=)
+bench=$(ps -C redis-benchmark -o pid=)
+sentinel=$(ps -C redis-sentinel -o pid=)
+
+if [[ ! -z "$srv$cli$bench$sentinel" ]]; then
+    exit 0
+fi
+
+exit 1

--- a/stacks/dbrs/releasenote.md
+++ b/stacks/dbrs/releasenote.md
@@ -1,0 +1,79 @@
+
+# Database Reference Stack
+
+The Database Reference Stack, an integrated, highly-performant open source stack optimized for next-generation 2nd Generation Intel® Xeon® Scalable processors with Intel® Optane™ DC persistent memory. This open source community release is part of our effort to ensure datacenters can reduce the bottlenecks and data latency by implementing intelligent, scalable and cost-effective storage mechanisms. The Database Reference Stack boosts the performance of data-intensive applications using traditional SSD storage drives by using DIMM modules as a persistant system storage.
+
+> **Note:**
+     For more information regarding Intel® Optane™ DC persistent memory please visit the [official Optane web page](https://www.intel.com/content/www/us/en/architecture-and-technology/intel-optane-technology.html).
+
+
+# The Database Reference Stack Releases
+
+To offer more flexibility, we are releasing multiple versions of the Database Reference Stack. All versions are built on top of the Clear Linux OS, which is optimized for I/O.
+
+> **Note:**
+     Clear Linux will be automatically updated to the latest release version in the container. The minimum validated version of Clear Linux for this stack is 30770.
+
+
+## The Database Reference Stack with Cassandra
+
+The release includes:
+  * Clear Linux* OS
+  * Cassandra 4.0 with persistent memory feature in App-Direct mode.
+  * PMDK 1.5.1 library as the storage engine
+  * openjdk 1.8.0
+
+> **Note:**
+     The PMDK library support has been added to the kernel since version 4.9, however it has more estability on kernel versions 5.0+
+
+
+## The Database Reference Stack with Redis
+
+The release includes:
+  * Clear Linux* OS
+  * Redis 4.0 with persistent memory feature in App-Direct mode.
+  * memkind 1.9.0 library as the storage engine
+
+## How to get the Database Reference Stack
+
+The official Database Reference Stack Docker images are hosted at: https://hub.docker.com/u/clearlinux/:
+
+ * Pull from the [Cassandra image](https://hub.docker.com/r/clearlinux/stacks-dbrs-cassandra)
+ * Pull from the [Redis image](https://hub.docker.com/r/clearlinux/stacks-dbrs-redis)
+
+
+# Licensing
+
+The Database Reference Stack is guided by the same [Terms of Use](https://download.clearlinux.org/TermsOfUse.html) declared by the Clear Linux project. The Docker images are hosted on https://hub.docker.com and as with all Docker images, these likely also contain other software which may be under other licenses (such as Bash, etc. from the base distribution, along with any direct or indirect dependencies of the primary software being contained).
+
+
+# Working with the Database Reference Stack
+
+The components of the Database Reference stack where selected because they support use of DCPMM in App-Direct Mode.
+
+The images can be used in a Kubernetes cluster as a multi-node environment. To enable DCPMM support in Kubernetes, it is required to use the [pmem-csi driver](https://github.com/intel/pmem-csi) to create the storage classes which will map to the DCPMM regions in fsdax mode.
+
+Please refer to the [Database Reference Stack tutorial](https://clearlinux.org/documentation/clear-linux/tutorials/dbrs) for detailed instructions for running the benchmarks on the docker images.
+
+
+# Contributing to the Database Reference Stack
+
+We encourage your contributions to this project, through the established Clear Linux community tools.  Our team uses typical open source collaboration tools that are described on the Clear Linux [community page](https://clearlinux.org/community).
+
+
+# Reporting Security Issues
+
+  If you have discovered potential security vulnerability in an Intel product, please contact the iPSIRT at secure@intel.com.
+
+  It is important to include the following details:
+
+  * The products and versions affected
+  * Detailed description of the vulnerability
+  * Information on known exploits
+
+  Vulnerability information is extremely sensitive. The iPSIRT strongly recommends that all security vulnerability reports sent to Intel be encrypted using the iPSIRT PGP key. The PGP key is available here: https://www.intel.com/content/www/us/en/security-center/pgp-public-key.html
+
+  Software to encrypt messages may be obtained from:
+
+  * PGP Corporation
+  * GnuPG


### PR DESCRIPTION
This commit includes the dockerfiles and documentation for Database Reference Stack v0.1.0, they will be located under stacks/dbrs directory. This version includes Redis and Cassandra applications.

Each application includes the scripts and conf directories with the files required for building the container.

For Cassandra there is a helm chart, and for Redis there is a yaml configuration file for a redisfailover instance. These files are included for an easier adoption as a kubernetes application.

Signed-off-by: Gabriel Briones <gabriel.briones.sayeg@intel.com>