### PR TITLE
Update DBRS v0.1.0 dockerfiles

### DIFF
--- a/stacks/dbrs/cassandra/Dockerfile
+++ b/stacks/dbrs/cassandra/Dockerfile
@@ -49,8 +49,7 @@ RUN  cd /tmp && \
      rm /workspace/cassandra/conf/cassandra.yaml && \
      rm /workspace/cassandra/conf/jvm-server.options && \
      rm /workspace/cassandra/conf/jvm8-server.options && \
-     rm /workspace/cassandra/conf/jvm11-server.options && \
-     rm /workspace/cassandra/lib/snappy-java-1.1.2.6.jar
+     rm /workspace/cassandra/conf/jvm11-server.options
 
 
 COPY conf/cassandra-template.yaml /workspace/cassandra/conf/

--- a/stacks/dbrs/redis/Dockerfile
+++ b/stacks/dbrs/redis/Dockerfile
@@ -1,7 +1,12 @@
 FROM clearlinux AS build-redis
 MAINTAINER otc-swstacks@intel.com
 
-RUN swupd bundle-add --quiet --no-progress git c-basic devpkg-ndctl os-testsuite-phoronix-server
+RUN swupd bundle-add --quiet --no-progress git c-basic devpkg-ndctl curl package-utils
+
+RUN clr_ver=$(grep VERSION_ID /usr/lib/os-release | awk -F= '{print $2}') && \
+	NUMA_DEV="https://cdn.download.clearlinux.org/releases/$clr_ver/clear/x86_64/os/Packages/numactl-dev-2.0.12-20.x86_64.rpm" && \
+	NUMA_LIB="https://cdn.download.clearlinux.org/releases/$clr_ver/clear/x86_64/os/Packages/numactl-lib-2.0.12-20.x86_64.rpm" && \
+	rpm -ihv --nodeps $NUMA_DEV $NUMA_LIB
 
 RUN  useradd redis-user
 


### PR DESCRIPTION
This PR includes 2 commits to update the Dockerfiles for stacks-dbrs-redis and stacks-dbrs-cassandra.

Avoid large bundle for stacks-dbrs-redis build:
    
    The package libnuma is required for Redis stack, the bundle which has
    this package is os-testsuite-phoronix, however, the size is too large.
    In order to avoid downloading the whole bundle, the package can be
    downloaded from Clear Linux published RPMs, this will save network
    bandwidth and build time.

Add snappy to stacks-dbrs-cassandra image
    
    Snappy is a library used for data compression, it is not stritctly
    required by Cassandra but can be very useful for large datasets.

Signed-off-by: Gabriel Briones <gabriel.briones.sayeg@intel.com>