### PR TITLE
Add post_push hooks to tag with redis version

### DIFF
--- a/docker-hooks.sh
+++ b/docker-hooks.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+CLR_URL="https://cdn.download.clearlinux.org/releases"
+
+# Return tag value or NULL if not found
+function get_tag {
+    pkg=$1
+
+    clr_ver=`docker run --rm clearlinux/os-core cat /usr/lib/os-release | grep VERSION_ID`
+    clr_ver=${clr_ver##*=}
+    src_url="$CLR_URL/$clr_ver/clear/source/package-sources"
+    matches=$(curl $src_url 2>/dev/null | grep $pkg)
+
+    # no matches, return NULL tag
+    if [ -z "$matches" ]; then
+        echo ""
+        echo "no $pkg found on the release $clr_ver"
+        exit 0
+    fi
+
+    matches=($matches)
+    for((j=0;j<${#matches[@]};j++))
+    do
+        if [ ${matches[j]} == $pkg ]; then
+            ver=${matches[j+1]}
+        fi
+    done
+
+    echo "$ver"
+}
+
+function get_tags_in_docker {
+    img=$1
+
+    tag_url="https://registry.hub.docker.com/v2/repositories/$img/tags/"
+    tags=$(curl $tag_url 2>/dev/null | docker run -i stedolan/jq  '."results"[]["name"]')
+    echo $tags
+}

--- a/redis/hooks/post_push
+++ b/redis/hooks/post_push
@@ -1,0 +1,19 @@
+#!/bin/bash
+echo "=> Tagging the image"
+
+set -e
+
+. ../docker-hooks.sh
+
+image="clearlinux/redis"
+tag=$(get_tag redis-native)
+
+if [ -z "$tag" ]; then
+    echo "no $pkg found on the release $clr_ver"
+else
+    docker tag $image:latest $image:$tag
+    docker push $image:$tag
+    major_tag=${tag%%.*}
+    docker tag $image:latest $image:$major_tag
+    docker push $image:$major_tag
+fi


### PR DESCRIPTION
Signed-off-by: Qi Zheng <qi.zheng@intel.com>

Using the docker build hooks way to tag the redis image.
https://docs.docker.com/docker-hub/builds/advanced/#custom-build-phase-hooks

Adding post_push script to do the tag with below steps.

1. Get container Clear Linux version from clearlinux/os-core because all the other containers are built on top of the clearlinux/os-core thus they have the same version.
2. Parse the "package-sources" file from that release version to get the app version according to the package name. In this case it is package redis-native.
3. Tag the latest container image with tag acquired on step 2 and push it.
4. Also tag it "major_tag" and push it. "major_tag" means the major version. 
For example, we got tag "5.0.6" in step 2, then the "major_tag" is "5".

For deleting obsolete tags, I don't find fully automatic way to do that.
Below commands can do the delete but it still requires the dockerhub USERNAME and PASSWORD.
I don't know how to handle/pass this sensitive info on open source scripts.
  $ tag_url="https://registry.hub.docker.com/v2/repositories/$image/tags/$TAG/"
  $ curl -u $USERNAME:$PASSWORD -X "DELETE" $tag_url
So I suggest that the deleting is taken manually by periodically check, for example once per month.