### PR TITLE
Unify the tags way

### DIFF
--- a/golang/hooks/post_push
+++ b/golang/hooks/post_push
@@ -1,13 +1,7 @@
 #!/bin/bash
-echo "=> Tagging the image"
-
 . ../docker-hooks.sh
 
 image="clearlinux/golang"
-tag=$(get_tag go)
+package=go
 
-if [ $? -eq 0 ] && [ -n "$tag" ]; then
-    # major tag format x.y, such as 1.12, 1.13
-    major_tag=${tag%.*}
-    tag_and_push $tag $major_tag
-fi
+do_tag $image $package

--- a/haproxy/hooks/post_push
+++ b/haproxy/hooks/post_push
@@ -1,13 +1,7 @@
 #!/bin/bash
-echo "=> Tagging the image"
-
 . ../docker-hooks.sh
 
 image="clearlinux/haproxy"
-tag=$(get_tag haproxy)
+package=haproxy
 
-if [ $? -eq 0 ] && [ -n "$tag" ]; then
-    # major tag format 1.6 or 2.0
-    major_tag=${tag%.*}
-    tag_and_push $tag $major_tag
-fi
+do_tag $image $package

--- a/httpd/hooks/post_push
+++ b/httpd/hooks/post_push
@@ -1,12 +1,7 @@
 #!/bin/bash
-echo "=> Tagging the image"
-
 . ../docker-hooks.sh
 
 image="clearlinux/httpd"
-tag=$(get_tag httpd)
+package=httpd
 
-if [ $? -eq 0 ] && [ -n "$tag" ]; then
-    major_tag=${tag%%.*}
-    tag_and_push $tag $major_tag
-fi
+do_tag $image $package

--- a/iperf/hooks/post_push
+++ b/iperf/hooks/post_push
@@ -1,12 +1,7 @@
 #!/bin/bash
-echo "=> Tagging the image"
-
 . ../docker-hooks.sh
 
 image="clearlinux/iperf"
-tag=$(get_tag iperf)
+package=iperf
 
-if [ $? -eq 0 ] && [ -n "$tag" ]; then
-    major_tag=${tag%%.*}
-    tag_and_push $tag $major_tag
-fi
+do_tag $image $package

--- a/mariadb/hooks/post_push
+++ b/mariadb/hooks/post_push
@@ -1,12 +1,7 @@
 #!/bin/bash
-echo "=> Tagging the image"
-
 . ../docker-hooks.sh
 
 image="clearlinux/mariadb"
-tag=$(get_tag mariadb)
+package=mariadb
 
-if [ $? -eq 0 ] && [ -n "$tag" ]; then
-    major_tag=${tag%%.*}
-    tag_and_push $tag $major_tag
-fi
+do_tag $image $package

--- a/memcached/hooks/post_push
+++ b/memcached/hooks/post_push
@@ -1,13 +1,7 @@
 #!/bin/bash
-echo "=> Tagging the image"
-
 . ../docker-hooks.sh
 
 image="clearlinux/memcached"
-tag=$(get_tag memcached)
+package=memcached
 
-if [ $? -eq 0 ] && [ -n "$tag" ]; then
-    # major tag format like 1.4 or 1.5
-    major_tag=${tag%.*}
-    tag_and_push $tag $major_tag
-fi
+do_tag $image $package

--- a/nginx/hooks/post_push
+++ b/nginx/hooks/post_push
@@ -1,13 +1,7 @@
 #!/bin/bash
-echo "=> Tagging the image"
-
 . ../docker-hooks.sh
 
 image="clearlinux/nginx"
-tag=$(get_tag nginx-mainline)
+package=nginx-mainline
 
-if [ $? -eq 0 ] && [ -n "$tag" ]; then
-    # major tag format 1.16 or 1.17
-    major_tag=${tag%.*}
-    tag_and_push $tag $major_tag
-fi
+do_tag $image $package

--- a/node/hooks/post_push
+++ b/node/hooks/post_push
@@ -1,12 +1,7 @@
 #!/bin/bash
-echo "=> Tagging the image"
-
 . ../docker-hooks.sh
 
 image="clearlinux/node"
-tag=$(get_tag nodejs)
+package=nodejs
 
-if [ $? -eq 0 ] && [ -n "$tag" ]; then
-    major_tag=${tag%%.*}
-    tag_and_push $tag $major_tag
-fi
+do_tag $image $package

--- a/openjdk/hooks/post_push
+++ b/openjdk/hooks/post_push
@@ -1,12 +1,7 @@
 #!/bin/bash
-echo "=> Tagging the image"
-
 . ../docker-hooks.sh
 
 image="clearlinux/openjdk"
-tag=$(get_tag openjdk13)
+package=openjdk13
 
-if [ $? -eq 0 ] && [ -n "$tag" ]; then
-    major_tag=${tag%%.*}
-    tag_and_push $tag $major_tag
-fi
+do_tag $image $package

--- a/openvino/hooks/post_push
+++ b/openvino/hooks/post_push
@@ -1,12 +1,7 @@
 #!/bin/bash
-echo "=> Tagging the image"
-
 . ../docker-hooks.sh
 
 image="clearlinux/openvino"
-tag=$(get_tag dldt)
+package=dldt
 
-if [ $? -eq 0 ] && [ -n "$tag" ]; then
-    major_tag=${tag%%.*}
-    tag_and_push $tag $major_tag
-fi
+do_tag $image $package

--- a/perl/hooks/post_push
+++ b/perl/hooks/post_push
@@ -1,12 +1,8 @@
 #!/bin/bash
-echo "=> Tagging the image"
-
 . ../docker-hooks.sh
 
 image="clearlinux/perl"
-tag=$(get_tag perl)
+package=perl
 
-if [ $? -eq 0 ] && [ -n "$tag" ]; then
-    major_tag=${tag%%.*}
-    tag_and_push $tag $major_tag
-fi
+do_tag $image $package
+

--- a/php-fpm/hooks/post_push
+++ b/php-fpm/hooks/post_push
@@ -1,12 +1,7 @@
 #!/bin/bash
-echo "=> Tagging the image"
-
 . ../docker-hooks.sh
 
 image="clearlinux/php-fpm"
-tag=$(get_tag php)
+package=php
 
-if [ $? -eq 0 ] && [ -n "$tag" ]; then
-    major_tag=${tag%%.*}
-    tag_and_push $tag $major_tag
-fi
+do_tag $image $package

--- a/php/hooks/post_push
+++ b/php/hooks/post_push
@@ -1,12 +1,7 @@
 #!/bin/bash
-echo "=> Tagging the image"
-
 . ../docker-hooks.sh
 
 image="clearlinux/php"
-tag=$(get_tag php)
+package=php
 
-if [ $? -eq 0 ] && [ -n "$tag" ]; then
-    major_tag=${tag%%.*}
-    tag_and_push $tag $major_tag
-fi
+do_tag $image $package

--- a/postgres/hooks/post_push
+++ b/postgres/hooks/post_push
@@ -1,12 +1,7 @@
 #!/bin/bash
-echo "=> Tagging the image"
-
 . ../docker-hooks.sh
 
 image="clearlinux/postgres"
-tag=$(get_tag postgresql11)
+package=postgresql11
 
-if [ $? -eq 0 ] && [ -n "$tag" ]; then
-    major_tag=${tag%%.*}
-    tag_and_push $tag $major_tag
-fi
+do_tag $image $package

--- a/python/hooks/post_push
+++ b/python/hooks/post_push
@@ -1,13 +1,7 @@
 #!/bin/bash
-echo "=> Tagging the image"
-
 . ../docker-hooks.sh
 
 image="clearlinux/python"
-tag=$(get_tag python3)
+package=python3
 
-if [ $? -eq 0 ] && [ -n "$tag" ]; then
-    # major tag format x.y, such as 3.6 , 3.7
-    major_tag=${tag%.*}
-    tag_and_push $tag $major_tag
-fi
+do_tag $image $package

--- a/rabbitmq/hooks/post_push
+++ b/rabbitmq/hooks/post_push
@@ -1,12 +1,7 @@
 #!/bin/bash
-echo "=> Tagging the image"
-
 . ../docker-hooks.sh
 
 image="clearlinux/rabbitmq"
-tag=$(get_tag rabbitmq-server)
+package=rabbitmq-server
 
-if [ $? -eq 0 ] && [ -n "$tag" ]; then
-    major_tag=${tag%%.*}
-    tag_and_push $tag $major_tag
-fi
+do_tag $image $package

--- a/redis/hooks/post_push
+++ b/redis/hooks/post_push
@@ -1,12 +1,7 @@
 #!/bin/bash
-echo "=> Tagging the image"
-
 . ../docker-hooks.sh
 
 image="clearlinux/redis"
-tag=$(get_tag redis-native)
+package=redis-native
 
-if [ $? -eq 0 ] && [ -n "$tag" ]; then
-    major_tag=${tag%%.*}
-    tag_and_push $tag $major_tag
-fi
+do_tag $image $package

--- a/ruby/hooks/post_push
+++ b/ruby/hooks/post_push
@@ -1,12 +1,7 @@
 #!/bin/bash
-echo "=> Tagging the image"
-
 . ../docker-hooks.sh
 
 image="clearlinux/ruby"
-tag=$(get_tag ruby)
+package=ruby
 
-if [ $? -eq 0 ] && [ -n "$tag" ]; then
-    major_tag=${tag%%.*}
-    tag_and_push $tag $major_tag
-fi
+do_tag $image $package

--- a/tensorflow-serving/hooks/post_push
+++ b/tensorflow-serving/hooks/post_push
@@ -1,13 +1,7 @@
 #!/bin/bash
-echo "=> Tagging the image"
-
 . ../docker-hooks.sh
 
 image="clearlinux/tensorflow-serving"
-tag=$(get_tag tensorflow-serving)
+package=tensorflow-serving
 
-if [ $? -eq 0 ] && [ -n "$tag" ]; then
-    # major tag format x.y, such as 1.14
-    major_tag=${tag%.*}
-    tag_and_push $tag $major_tag
-fi
+do_tag $image $package

--- a/tensorflow/hooks/post_push
+++ b/tensorflow/hooks/post_push
@@ -1,13 +1,7 @@
 #!/bin/bash
-echo "=> Tagging the image"
-
 . ../docker-hooks.sh
 
 image="clearlinux/tensorflow"
-tag=$(get_tag tensorflow)
+package=tensorflow
 
-if [ $? -eq 0 ] && [ -n "$tag" ]; then
-    # major tag format x.y, such as 1.16
-    major_tag=${tag%.*}
-    tag_and_push $tag $major_tag
-fi
+do_tag $image $package


### PR DESCRIPTION
For version format x.y.z, three tags as below
    tag: x.y.z
    tag1: x.y
    tag2: x
They all point to the latest image.
Once app got updated (minor updates, z to z1), the tag x.y.z
will be replaced by x.y.z1, but the tag x or x.y may still
keep.

Signed-off-by: Qi Zheng <qi.zheng@intel.com>