### PR TITLE
Deprecates MAINTAINER in Dockerfile to follow dockerhub official guide.

### DIFF
--- a/cassandra/Dockerfile
+++ b/cassandra/Dockerfile
@@ -30,7 +30,6 @@ RUN cd / && \
     find os_core_install | sed -e 's/os_core_install/install_root/' | xargs rm -d &> /dev/null || true
 
 FROM clearlinux/os-core:latest
-MAINTAINER wang.jue@intel.com
 
 COPY --from=builder /install_root /
 

--- a/clr-installer-ci/Dockerfile
+++ b/clr-installer-ci/Dockerfile
@@ -1,5 +1,4 @@
 FROM clearlinux:latest
-MAINTAINER mark.d.horn@intel.com
 
 # Configure Go
 ENV GOPATH="/go" PATH="/go/bin:${PATH}"

--- a/clr-sdk/Dockerfile
+++ b/clr-sdk/Dockerfile
@@ -1,5 +1,4 @@
 FROM clearlinux:latest
-MAINTAINER kevin.c.wells@intel.com
 
 ARG swupd_args
 

--- a/elasticsearch/Dockerfile
+++ b/elasticsearch/Dockerfile
@@ -1,5 +1,4 @@
 FROM clearlinux:latest AS builder
-MAINTAINER qi.zheng@intel.com
 
 ARG swupd_args
 # Move to latest Clear Linux release to ensure

--- a/flink/Dockerfile
+++ b/flink/Dockerfile
@@ -1,5 +1,4 @@
 FROM clearlinux:latest AS builder
-MAINTAINER hongzhan.chen@intel.com
 
 ARG swupd_args
 # Move to latest Clear Linux release to ensure

--- a/golang/Dockerfile
+++ b/golang/Dockerfile
@@ -1,5 +1,4 @@
 FROM clearlinux:latest AS builder
-MAINTAINER qi.zheng@intel.com
 
 ARG swupd_args
 # Move to latest Clear Linux release to ensure

--- a/gonum/Dockerfile
+++ b/gonum/Dockerfile
@@ -1,5 +1,4 @@
 FROM clearlinux:latest AS builder
-MAINTAINER jing.j.wang@intel.com
 
 ARG swupd_args
 # Move to latest Clear Linux release to ensure

--- a/haproxy/Dockerfile
+++ b/haproxy/Dockerfile
@@ -1,5 +1,4 @@
 FROM clearlinux:latest  AS builder
-MAINTAINER sophia.gong@intel.com
 
 ARG swupd_args
 # Move to latest Clear Linux release to ensure

--- a/httpd/Dockerfile
+++ b/httpd/Dockerfile
@@ -28,7 +28,6 @@ RUN cd / && \
     find os_core_install | sed -e 's/os_core_install/install_root/' | xargs rm -d &> /dev/null || true
 
 FROM clearlinux/os-core:latest
-MAINTAINER qi.zheng@intel.com
 
 COPY --from=builder /install_root /
 

--- a/iperf/Dockerfile
+++ b/iperf/Dockerfile
@@ -1,5 +1,4 @@
 FROM clearlinux:latest  AS builder
-MAINTAINER long1.wang@intel.com
 
 ARG swupd_args
 # Move to latest Clear Linux release to ensure

--- a/machine-learning-ui/Dockerfile
+++ b/machine-learning-ui/Dockerfile
@@ -1,5 +1,4 @@
 FROM clearlinux
-MAINTAINER william.douglas@intel.com
 
 ARG swupd_args
 

--- a/mariadb/Dockerfile
+++ b/mariadb/Dockerfile
@@ -29,7 +29,6 @@ RUN cd / && \
     find os_core_install | sed -e 's/os_core_install/install_root/' | xargs rm -d &> /dev/null || true
 
 FROM clearlinux/os-core:latest
-MAINTAINER qi.zheng@intel.com
 
 COPY --from=builder /install_root /
 

--- a/memcached/Dockerfile
+++ b/memcached/Dockerfile
@@ -28,7 +28,6 @@ RUN cd / && \
     find os_core_install | sed -e 's/os_core_install/install_root/' | xargs rm -d &> /dev/null || true
 
 FROM clearlinux/os-core:latest
-MAINTAINER qi.zheng@intel.com
 
 COPY --from=builder /install_root /
 

--- a/mixer-ci/Dockerfile
+++ b/mixer-ci/Dockerfile
@@ -1,5 +1,4 @@
 FROM clearlinux:latest
-MAINTAINER kevin.c.wells@intel.com
 
 # Configure Go
 ENV GOPATH /home/clr/go

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -28,7 +28,6 @@ RUN cd / && \
     find os_core_install | sed -e 's/os_core_install/install_root/' | xargs rm -d &> /dev/null || true
 
 FROM clearlinux/os-core:latest
-MAINTAINER qi.zheng@intel.com
 
 COPY --from=builder /install_root /
 COPY default.conf /etc/nginx-mainline/conf.d/default.conf

--- a/node/Dockerfile
+++ b/node/Dockerfile
@@ -1,5 +1,4 @@
 FROM clearlinux:latest AS builder
-MAINTAINER jianjun.liu@intel.com
 
 ARG swupd_args
 # Move to latest Clear Linux release to ensure

--- a/numpy-mp/Dockerfile
+++ b/numpy-mp/Dockerfile
@@ -1,5 +1,4 @@
 FROM clearlinux:latest AS builder
-MAINTAINER long1.wang@intel.com
 
 ARG swupd_args
 # Move to latest Clear Linux release to ensure

--- a/openjdk/13/Dockerfile
+++ b/openjdk/13/Dockerfile
@@ -1,5 +1,4 @@
 FROM clearlinux:latest AS builder
-MAINTAINER long1.wang@intel.com
 
 ARG swupd_args
 # Move to latest Clear Linux release to ensure

--- a/openjdk/8/Dockerfile
+++ b/openjdk/8/Dockerfile
@@ -1,5 +1,4 @@
 FROM clearlinux:latest AS builder
-MAINTAINER qi.zheng@intel.com
 
 ARG swupd_args
 # Move to latest Clear Linux release to ensure

--- a/openvino/Dockerfile
+++ b/openvino/Dockerfile
@@ -28,7 +28,6 @@ RUN cd / && \
     find os_core_install | sed -e 's/os_core_install/install_root/' | xargs rm -d &> /dev/null || true
 
 FROM clearlinux/os-core:latest
-MAINTAINER qi.zheng@intel.com
 
 COPY --from=builder /install_root /
 

--- a/perl/Dockerfile
+++ b/perl/Dockerfile
@@ -1,5 +1,4 @@
 FROM clearlinux:latest AS builder
-MAINTAINER qi.zheng@intel.com
 
 ARG swupd_args
 # Move to latest Clear Linux release to ensure

--- a/php-fpm/Dockerfile
+++ b/php-fpm/Dockerfile
@@ -1,5 +1,4 @@
 FROM clearlinux:latest AS builder
-MAINTAINER sophia.gong@intel.com
 
 ARG swupd_args
 # Move to latest Clear Linux release to ensure

--- a/php/Dockerfile
+++ b/php/Dockerfile
@@ -1,5 +1,4 @@
 FROM clearlinux:latest AS builder
-MAINTAINER jianjun.liu@intel.com
 
 ARG swupd_args
 # Move to latest Clear Linux release to ensure

--- a/postgres/Dockerfile
+++ b/postgres/Dockerfile
@@ -1,5 +1,4 @@
 FROM clearlinux:latest AS builder
-MAINTAINER william.douglas@intel.com
 
 ARG swupd_args
 # Move to latest Clear Linux release to ensure

--- a/python/Dockerfile
+++ b/python/Dockerfile
@@ -1,5 +1,4 @@
 FROM clearlinux:latest AS builder
-MAINTAINER hongzhan.chen@intel.com
 
 ARG swupd_args
 # Move to latest Clear Linux release to ensure

--- a/rabbitmq/Dockerfile
+++ b/rabbitmq/Dockerfile
@@ -1,5 +1,4 @@
 FROM clearlinux:latest AS builder
-MAINTAINER long1.wang@intel.com
 
 ARG swupd_args
 # Move to latest Clear Linux release to ensure

--- a/redis/Dockerfile
+++ b/redis/Dockerfile
@@ -28,7 +28,6 @@ RUN cd / && \
     find os_core_install | sed -e 's/os_core_install/install_root/' | xargs rm -d &> /dev/null || true
 
 FROM clearlinux/os-core:latest
-MAINTAINER qi.zheng@intel.com
 
 COPY --from=builder /install_root /
 

--- a/ruby/Dockerfile
+++ b/ruby/Dockerfile
@@ -1,5 +1,4 @@
 FROM clearlinux:latest AS builder
-MAINTAINER hongzhan.chen@intel.com
 
 ARG swupd_args
 # Move to latest Clear Linux release to ensure

--- a/stacks/dbrs/cassandra/Dockerfile
+++ b/stacks/dbrs/cassandra/Dockerfile
@@ -1,5 +1,4 @@
 FROM clearlinux/stacks-clearlinux:latest
-MAINTAINER otc-swstacks@intel.com
 
 RUN swupd bundle-add curl java-runtime python2-basic which pmdk sudo
 

--- a/stacks/dbrs/redis/Dockerfile
+++ b/stacks/dbrs/redis/Dockerfile
@@ -1,5 +1,4 @@
 FROM clearlinux AS build-redis
-MAINTAINER otc-swstacks@intel.com
 
 RUN swupd bundle-add --quiet --no-progress git c-basic devpkg-ndctl curl package-utils
 

--- a/tensorflow-serving/Dockerfile
+++ b/tensorflow-serving/Dockerfile
@@ -1,5 +1,4 @@
 FROM clearlinux:latest AS builder
-MAINTAINER jianjun.liu@intel.com
 
 ARG swupd_args
 # Move to latest Clear Linux release to ensure

--- a/tensorflow/Dockerfile
+++ b/tensorflow/Dockerfile
@@ -1,5 +1,4 @@
 FROM clearlinux:latest AS builder
-MAINTAINER jianjun.liu@intel.com
 
 ARG swupd_args
 # Move to latest Clear Linux release to ensure

--- a/tesseract-ocr/Dockerfile
+++ b/tesseract-ocr/Dockerfile
@@ -1,5 +1,4 @@
 FROM clearlinux:latest AS builder
-MAINTAINER jing.j.wang@intel.com
 
 ARG swupd_args
 # Move to latest Clear Linux release to ensure

--- a/tomcat/Dockerfile
+++ b/tomcat/Dockerfile
@@ -1,5 +1,4 @@
 FROM clearlinux:latest AS builder
-MAINTAINER long1.wang@intel.com
 
 ARG swupd_args
 # Move to latest Clear Linux release to ensure

--- a/wordpress/Dockerfile
+++ b/wordpress/Dockerfile
@@ -1,5 +1,4 @@
 FROM clearlinux/php-fpm
-MAINTAINER sophia.gong@intel.com
 
 VOLUME /var/www/html
 


### PR DESCRIPTION
(https://docs.docker.com/engine/reference/builder/#/maintainer-deprecated)

Signed-off-by: Gong Sophia <sophia.gong@intel.com>