### PR TITLE
use `--no-cache-dir` flag to `pip` in dockerfiles to save space

### DIFF
--- a/FaaS/OpenFaaS/template/numpy-mp/Dockerfile
+++ b/FaaS/OpenFaaS/template/numpy-mp/Dockerfile
@@ -14,7 +14,7 @@ WORKDIR /home/numpy-func
 COPY function /home/numpy-func/function
 WORKDIR /home/numpy-func/function
 # pip install python packages if required
-RUN pip install -r requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
 
 # install bundles if required
 # PLEASE input bundle line by line

--- a/FaaS/OpenFaaS/template/python3-clearlinux/Dockerfile
+++ b/FaaS/OpenFaaS/template/python3-clearlinux/Dockerfile
@@ -16,7 +16,7 @@ RUN touch ./function/__init__.py
 WORKDIR /root/function/
 # pip install python packages if required
 COPY function/requirements.txt  .
-RUN pip install -r requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
 
 # install bundles if required
 # PLEASE input bundle line by line

--- a/openvino/Dockerfile
+++ b/openvino/Dockerfile
@@ -52,7 +52,7 @@ RUN for m in $(cat /app/models.txt); do \
 
 # Pre-install some python libs for serivce to use
 COPY ./requirements.txt /app
-RUN pip3 install -r /app/requirements.txt
+RUN pip3 install --no-cache-dir -r /app/requirements.txt
 
 COPY ./set_model_path.sh /app
 COPY docker-entrypoint.sh /usr/local/bin/

--- a/stacks/dlrs/kubeflow/dlrs-seldon/docker/Dockerfile_openvino_base
+++ b/stacks/dlrs/kubeflow/dlrs-seldon/docker/Dockerfile_openvino_base
@@ -1,7 +1,7 @@
 FROM clearlinux/stacks-dlrs-mkl:v0.4.0
 
-RUN pip install jaeger-client==3.13.0 seldon-core tornado>=5.0\
-    && pip install --upgrade setuptools \
+RUN pip install --no-cache-dir jaeger-client==3.13.0 seldon-core tornado>=5.0\
+    && pip install --no-cache-dir --upgrade setuptools \
     && sed -i "s/max_workers=10/max_workers=1/g" /usr/lib/python3.7/site-packages/seldon_core/wrapper.py
 
 RUN git clone https://github.com/SeldonIO/seldon-core.git /opt/seldon-core \


### PR DESCRIPTION
using "--no-cache-dir" flag in pip install ,make sure downloaded packages
by pip don't cached on system . This is a best practice which make sure
to fetch from repo instead of using local cached one . Further , in case
of Docker Containers , by restricting caching , we can reduce image size.
In term of stats , it depends upon the number of python packages
multiplied by their respective size . e.g for heavy packages with a lot
of dependencies it reduce a lot by don't caching pip packages.

Further , more detail information can be found at

https://medium.com/sciforce/strategies-of-docker-images-optimization-2ca9cc5719b6

Signed-off-by: Pratik Raj <rajpratik71@gmail.com>