### PR TITLE
[docker] : optimization in git clone using --depth

### DIFF
--- a/stacks/dlrs/kubeflow/dlrs-seldon/docker/Dockerfile_openvino_base
+++ b/stacks/dlrs/kubeflow/dlrs-seldon/docker/Dockerfile_openvino_base
@@ -4,7 +4,7 @@ RUN pip install jaeger-client==3.13.0 seldon-core tornado>=5.0\
     && pip install --upgrade setuptools \
     && sed -i "s/max_workers=10/max_workers=1/g" /usr/lib/python3.7/site-packages/seldon_core/wrapper.py
 
-RUN git clone https://github.com/SeldonIO/seldon-core.git /opt/seldon-core \
+RUN git clone --depth 1 https://github.com/SeldonIO/seldon-core.git /opt/seldon-core \
     && mkdir -p /s2i/bin \
     && cp -a /opt/seldon-core/wrappers/s2i/python/s2i/bin/ /s2i/bin/
     

--- a/stacks/dlrs/kubeflow/dlrs-tfjob/tf_cnn_benchmarks/Dockerfile
+++ b/stacks/dlrs/kubeflow/dlrs-tfjob/tf_cnn_benchmarks/Dockerfile
@@ -2,7 +2,7 @@
 FROM clearlinux/stacks-dlrs-mkl:1390
 
 RUN mkdir -p /opt
-RUN git clone https://github.com/tensorflow/benchmarks.git /opt/tf-benchmarks
+RUN git clone --depth 1 https://github.com/tensorflow/benchmarks.git /opt/tf-benchmarks
 
 COPY launcher.py /opt
 RUN chmod u+x /opt/*


### PR DESCRIPTION
optimize the git clone using --depth flag in term of size of clone
and also in term's of time taken to fetch the files and commit history
of whole repository .

More detail can be found at blog
https://www.atlassian.com/git/tutorials/big-repositories

Signed-off-by: Pratik Raj <rajpratik71@gmail.com>