### PR TITLE
fix github workflow for building test docker images

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,7 +41,7 @@ jobs:
     - name: install
       run: | 
         sudo apt-get purge moby-engine moby-cli 
-        sudo apt-get install docker.io bats -f
+        sudo apt-get install docker-ce bats -f
         sudo modprobe -r overlay
         sudo modprobe overlay redirect_dir=off
         sudo systemctl restart docker


### PR DESCRIPTION
Move "docker" package from "docker.io" to "docker-ce"

Signed-off-by: Pratik raj <rajpratik71@gmail.com>